### PR TITLE
Add created_from metadata to OpenClaw traces

### DIFF
--- a/src/service.test.ts
+++ b/src/service.test.ts
@@ -291,6 +291,7 @@ describe("opik service", () => {
           threadId: "session-1",
           input: expect.objectContaining({ prompt: "Hello", systemPrompt: "You are helpful" }),
           metadata: expect.objectContaining({
+            created_from: "openclaw",
             provider: "openai",
             model: "gpt-4",
             channel: "telegram",
@@ -1571,6 +1572,7 @@ describe("opik service", () => {
 
       expect(metadata.model).toBe("gpt-4");
       expect(metadata.provider).toBe("openai");
+      expect(metadata.created_from).toBe("openclaw");
       expect(metadata.channel).toBe("discord");
       expect(metadata.channelId).toBe("discord");
       expect(metadata.trigger).toBe("cron");

--- a/src/service.ts
+++ b/src/service.ts
@@ -17,6 +17,7 @@ import {
   DEFAULT_STALE_SWEEP_INTERVAL_MS,
   DEFAULT_STALE_TRACE_TIMEOUT_MS,
   MAX_FLUSH_RETRY_DELAY_MS,
+  OPIK_CREATED_FROM,
   OPIK_PLUGIN_ID,
 } from "./service/constants.js";
 import {
@@ -258,6 +259,7 @@ export function createOpikService(
 
     const agentEnd = active.agentEnd;
     const metadata: Record<string, unknown> = {
+      created_from: OPIK_CREATED_FROM,
       ...active.costMeta,
       success: agentEnd?.success,
       durationMs: agentEnd?.durationMs,

--- a/src/service/constants.ts
+++ b/src/service/constants.ts
@@ -4,6 +4,7 @@ export const DEFAULT_FLUSH_RETRY_COUNT = 2;
 export const DEFAULT_FLUSH_RETRY_BASE_DELAY_MS = 250;
 export const MAX_FLUSH_RETRY_DELAY_MS = 5000;
 export const OPIK_PLUGIN_ID = "opik-openclaw";
+export const OPIK_CREATED_FROM = "openclaw";
 
 export const LOCAL_ATTACHMENT_UPLOAD_MAGIC_ID = "BEMinIO";
 export const ATTACHMENT_UPLOAD_PART_SIZE_BYTES = 8 * 1024 * 1024;

--- a/src/service/hooks/llm.ts
+++ b/src/service/hooks/llm.ts
@@ -1,6 +1,7 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { Opik, Span, Trace } from "opik";
 import type { ActiveTrace } from "../../types.js";
+import { OPIK_CREATED_FROM } from "../constants.js";
 import {
   mapUsageToOpikTokens,
   normalizeProvider,
@@ -63,6 +64,7 @@ export function registerLlmHooks(deps: LlmHooksDeps): void {
         threadId: sessionKey,
         input: sanitizedTraceInput,
         metadata: {
+          created_from: OPIK_CREATED_FROM,
           provider: normalizedProvider,
           model: event.model,
           sessionId: event.sessionId,


### PR DESCRIPTION
## Details
- add a shared `openclaw` created-from marker for the integration
- include `metadata.created_from` when traces are created through the TypeScript SDK
- include the same marker in deferred trace finalization metadata so the field stays explicit on updates

## Change checklist
- [ ] User facing
- [ ] Documentation updated (if needed)
- [x] Tests added/updated (if needed)
- [ ] Breaking changes documented (if any)

## Issues
- Resolves #
- OPIK-

## Testing
- npm run lint
- npm run typecheck
- npm run test
- npm run smoke

## Documentation
- No documentation changes required.