### PR TITLE
chore(release): bump version to 0.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opik/opik-openclaw",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opik/opik-openclaw",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "dependencies": {
         "@clack/prompts": "^1.0.1",
         "opik": "^1.10.25"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opik/opik-openclaw",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "license": "Apache-2.0",
   "description": "OpenClaw Opik exporter — sends LLM traces to Opik",
   "repository": {


### PR DESCRIPTION
## Details
- bump `@opik/opik-openclaw` from `0.2.5` to `0.2.6`
- package the merged `created_from` trace metadata fix from #25 into the next patch release

## Change checklist
- [ ] User facing
- [ ] Documentation updated (if needed)
- [x] Tests added/updated (if needed)
- [ ] Breaking changes documented (if any)

## Issues
- Resolves #
- OPIK-

## Testing
- npm run lint
- npm run typecheck
- npm run test
- npm run smoke
- npm pack --dry-run

## Documentation
- No documentation changes required.