### PR TITLE
fix: restore nested subagent and tool span parenting

### DIFF
--- a/src/service.test.ts
+++ b/src/service.test.ts
@@ -1157,6 +1157,89 @@ describe("opik service", () => {
       expect(mockToolSpanB.end).toHaveBeenCalledTimes(1);
     });
 
+    test("nests child-session tool spans under the active subagent span", async () => {
+      const { api, hooks } = createApi();
+      const parentTrace = opikState.createMockTrace();
+      const childTrace = opikState.createMockTrace();
+      const parentLlmSpan = opikState.createMockSpan();
+      const childLlmSpan = opikState.createMockSpan();
+      const childSubagentSpan = opikState.createMockSpan();
+      const nestedToolSpan = opikState.createMockSpan();
+
+      parentTrace.span.mockReturnValueOnce(parentLlmSpan).mockReturnValueOnce(childSubagentSpan);
+      childTrace.span.mockReturnValueOnce(childLlmSpan);
+      childSubagentSpan.span.mockReturnValueOnce(nestedToolSpan);
+      mockTraceFn.mockReturnValueOnce(parentTrace).mockReturnValueOnce(childTrace);
+
+      const service = createOpikService(api as any);
+      await service.start(createServiceContext() as any);
+
+      invokeHook(
+        hooks,
+        "llm_input",
+        { model: "parent-model", provider: "p", prompt: "" },
+        agentCtx("parent-session", { agentId: "parent-agent" }),
+      );
+      invokeHook(
+        hooks,
+        "subagent_spawning",
+        {
+          childSessionKey: "child-session",
+          agentId: "writer",
+          mode: "run",
+        },
+        { requesterSessionKey: "parent-session", childSessionKey: "child-session", runId: "run-sub-1" },
+      );
+      invokeHook(
+        hooks,
+        "llm_input",
+        { model: "child-model", provider: "p", prompt: "" },
+        agentCtx("child-session", { agentId: "child-agent" }),
+      );
+
+      invokeHook(
+        hooks,
+        "before_tool_call",
+        {
+          toolName: "search",
+          params: { q: "nested" },
+          toolCallId: "call-child",
+        },
+        toolCtx("child-session", { agentId: "child-agent" }),
+      );
+      invokeHook(
+        hooks,
+        "after_tool_call",
+        {
+          toolName: "search",
+          result: { ok: true },
+          toolCallId: "call-child",
+        },
+        toolCtx("child-session", { agentId: "child-agent" }),
+      );
+
+      expect(childSubagentSpan.span).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "search",
+          type: "tool",
+          input: { q: "nested" },
+          metadata: {
+            agentId: "child-agent",
+            toolCallId: "call-child",
+          },
+        }),
+      );
+      expect(childTrace.span).toHaveBeenCalledTimes(1);
+      expect(nestedToolSpan.update).toHaveBeenCalledWith({
+        metadata: {
+          agentId: "child-agent",
+          toolCallId: "call-child",
+        },
+        output: { ok: true },
+      });
+      expect(nestedToolSpan.end).toHaveBeenCalledTimes(1);
+    });
+
     test("falls back via agentId when sessionKey is missing and multiple traces are active", async () => {
       const { api, hooks } = createApi();
       const traceA = opikState.createMockTrace();
@@ -1373,6 +1456,98 @@ describe("opik service", () => {
           originThreadId: 42,
         },
       });
+    });
+
+    test("nests grandchild subagent spans under the requester subagent span", async () => {
+      const { api, hooks } = createApi();
+      const parentTrace = opikState.createMockTrace();
+      const childTrace = opikState.createMockTrace();
+      const parentLlmSpan = opikState.createMockSpan();
+      const childLlmSpan = opikState.createMockSpan();
+      const childSubagentSpan = opikState.createMockSpan();
+      const grandchildSubagentSpan = opikState.createMockSpan();
+
+      parentTrace.span.mockReturnValueOnce(parentLlmSpan).mockReturnValueOnce(childSubagentSpan);
+      childTrace.span.mockReturnValueOnce(childLlmSpan);
+      childSubagentSpan.span.mockReturnValueOnce(grandchildSubagentSpan);
+      mockTraceFn.mockReturnValueOnce(parentTrace).mockReturnValueOnce(childTrace);
+
+      const service = createOpikService(api as any);
+      await service.start(createServiceContext() as any);
+
+      invokeHook(
+        hooks,
+        "llm_input",
+        { model: "parent-model", provider: "p", prompt: "" },
+        agentCtx("parent-session", { agentId: "parent-agent" }),
+      );
+      invokeHook(
+        hooks,
+        "subagent_spawning",
+        {
+          childSessionKey: "child-session",
+          agentId: "writer",
+          mode: "run",
+        },
+        { requesterSessionKey: "parent-session", childSessionKey: "child-session", runId: "run-child-1" },
+      );
+      invokeHook(
+        hooks,
+        "llm_input",
+        { model: "child-model", provider: "p", prompt: "" },
+        agentCtx("child-session", { agentId: "child-agent" }),
+      );
+
+      invokeHook(
+        hooks,
+        "subagent_spawning",
+        {
+          childSessionKey: "grandchild-session",
+          agentId: "reviewer",
+          mode: "run",
+        },
+        { requesterSessionKey: "child-session", childSessionKey: "grandchild-session", runId: "run-grandchild-1" },
+      );
+      invokeHook(
+        hooks,
+        "subagent_spawned",
+        {
+          childSessionKey: "grandchild-session",
+          agentId: "reviewer",
+          mode: "run",
+          runId: "run-grandchild-1",
+        },
+        { requesterSessionKey: "child-session", childSessionKey: "grandchild-session", runId: "run-grandchild-1" },
+      );
+      invokeHook(
+        hooks,
+        "subagent_ended",
+        {
+          targetSessionKey: "grandchild-session",
+          targetKind: "subagent",
+          reason: "completed",
+          outcome: "ok",
+        },
+        { requesterSessionKey: "child-session", childSessionKey: "grandchild-session", runId: "run-grandchild-1" },
+      );
+
+      expect(childSubagentSpan.span).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "subagent:reviewer",
+          input: expect.objectContaining({ childSessionKey: "grandchild-session" }),
+        }),
+      );
+      expect(childTrace.span).toHaveBeenCalledTimes(1);
+      expect(grandchildSubagentSpan.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            status: "spawned",
+            childSessionKey: "grandchild-session",
+            runId: "run-grandchild-1",
+          }),
+        }),
+      );
+      expect(grandchildSubagentSpan.end).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -49,6 +49,10 @@ export function createOpikService(
 ): OpenClawPluginService {
   let client: Opik | null = null;
   const activeTraces = new Map<string, ActiveTrace>();
+  const subagentSpanHosts = new Map<
+    string,
+    { hostSessionKey: string; active: ActiveTrace; span: Span }
+  >();
   const sessionByAgentId = new Map<string, string>();
   let cleanup: (() => void) | null = null;
   let spanSeq = 0;
@@ -111,6 +115,33 @@ export function createOpikService(
     for (const [agentId, mappedSessionKey] of sessionByAgentId) {
       if (mappedSessionKey === sessionKey) {
         sessionByAgentId.delete(agentId);
+      }
+    }
+  }
+
+  function rememberSubagentSpanHost(
+    sessionKey: string,
+    hostSessionKey: string,
+    active: ActiveTrace,
+    span: Span,
+  ): void {
+    subagentSpanHosts.set(sessionKey, { hostSessionKey, active, span });
+  }
+
+  function getSubagentSpanHost(
+    sessionKey: string,
+  ): { hostSessionKey: string; active: ActiveTrace; span: Span } | undefined {
+    return subagentSpanHosts.get(sessionKey);
+  }
+
+  function forgetSubagentSpanHost(sessionKey: string): void {
+    subagentSpanHosts.delete(sessionKey);
+  }
+
+  function forgetSubagentSpanHostsByActive(active: ActiveTrace): void {
+    for (const [sessionKey, spanHost] of subagentSpanHosts) {
+      if (spanHost.active === active) {
+        subagentSpanHosts.delete(sessionKey);
       }
     }
   }
@@ -178,6 +209,7 @@ export function createOpikService(
 
   function closeActiveTrace(active: ActiveTrace, reason: string): void {
     endChildSpans(active, reason);
+    forgetSubagentSpanHostsByActive(active);
 
     // Clear deferred finalization state so stale microtasks no-op.
     active.agentEnd = undefined;
@@ -186,17 +218,44 @@ export function createOpikService(
     safeTraceEnd(active.trace, reason);
   }
 
-  function resolveSubagentHostTrace(params: {
+  function resolveSessionSpanContainer(
+    sessionKey: string,
+  ): { sessionKey: string; active: ActiveTrace; parent: Trace | Span } | undefined {
+    const spanHost = getSubagentSpanHost(sessionKey);
+    if (spanHost) {
+      return {
+        sessionKey: spanHost.hostSessionKey,
+        active: spanHost.active,
+        parent: spanHost.span,
+      };
+    }
+
+    const active = activeTraces.get(sessionKey);
+    if (active) {
+      return { sessionKey, active, parent: active.trace };
+    }
+
+    return undefined;
+  }
+
+  function resolveSubagentSpanContainer(params: {
     requesterSessionKey?: string;
     childSessionKey?: string;
     targetSessionKey?: string;
-  }): { sessionKey: string; active: ActiveTrace } | undefined {
-    const candidates = [params.requesterSessionKey, params.childSessionKey, params.targetSessionKey];
+  }): { sessionKey: string; active: ActiveTrace; parent: Trace | Span } | undefined {
+    if (params.requesterSessionKey) {
+      const requesterContainer = resolveSessionSpanContainer(params.requesterSessionKey);
+      if (requesterContainer) {
+        return requesterContainer;
+      }
+    }
+
+    const candidates = [params.childSessionKey, params.targetSessionKey];
     for (const key of candidates) {
       if (!key) continue;
       const active = activeTraces.get(key);
       if (active) {
-        return { sessionKey: key, active };
+        return { sessionKey: key, active, parent: active.trace };
       }
     }
     return undefined;
@@ -303,6 +362,7 @@ export function createOpikService(
     );
 
     safeTraceEnd(active.trace, `finalize sessionKey=${sessionKey}`);
+    forgetSubagentSpanHostsByActive(active);
     activeTraces.delete(sessionKey);
     forgetSessionCorrelation(sessionKey);
     scheduleFlush(`trace-finalized sessionKey=${sessionKey}`);
@@ -377,6 +437,7 @@ export function createOpikService(
         sessionByAgentId,
         getLastActiveSessionKey: () => lastActiveSessionKey,
         rememberSessionCorrelation,
+        resolveSessionSpanContainer,
         warnMissingAfterToolSessionKey,
         nextSpanSeq: () => ++spanSeq,
         safeSpanUpdate,
@@ -391,7 +452,10 @@ export function createOpikService(
         api,
         getClient: () => client,
         rememberSessionCorrelation,
-        resolveSubagentHostTrace,
+        resolveSubagentSpanContainer,
+        getSubagentSpanHost,
+        rememberSubagentSpanHost,
+        forgetSubagentSpanHost,
         safeSpanUpdate,
         safeSpanEnd,
         warn: (message) => log.warn(message),
@@ -533,6 +597,7 @@ export function createOpikService(
                 );
 
                 safeTraceEnd(active.trace, `stale cleanup sessionKey=${key}`);
+                forgetSubagentSpanHostsByActive(active);
                 activeTraces.delete(key);
                 forgetSessionCorrelation(key);
               }

--- a/src/service/hooks/subagent.ts
+++ b/src/service/hooks/subagent.ts
@@ -1,5 +1,5 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import type { Opik, Span } from "opik";
+import type { Opik, Span, Trace } from "opik";
 import type { ActiveTrace } from "../../types.js";
 import { asNonEmptyString } from "../helpers.js";
 import { sanitizeStringForOpik } from "../payload-sanitizer.js";
@@ -13,11 +13,21 @@ type SubagentHooksDeps = {
   api: OpenClawPluginApi;
   getClient: () => Opik | null;
   rememberSessionCorrelation: (sessionKey: string, agentId?: unknown) => void;
-  resolveSubagentHostTrace: (params: {
+  resolveSubagentSpanContainer: (params: {
     requesterSessionKey?: string;
     childSessionKey?: string;
     targetSessionKey?: string;
-  }) => { sessionKey: string; active: ActiveTrace } | undefined;
+  }) => { sessionKey: string; active: ActiveTrace; parent: Trace | Span } | undefined;
+  getSubagentSpanHost: (
+    sessionKey: string,
+  ) => { hostSessionKey: string; active: ActiveTrace; span: Span } | undefined;
+  rememberSubagentSpanHost: (
+    sessionKey: string,
+    hostSessionKey: string,
+    active: ActiveTrace,
+    span: Span,
+  ) => void;
+  forgetSubagentSpanHost: (sessionKey: string) => void;
   safeSpanUpdate: (span: Span, payload: Record<string, unknown>, reason: string) => void;
   safeSpanEnd: (span: Span, reason: string) => void;
   warn: (message: string) => void;
@@ -36,20 +46,21 @@ export function registerSubagentHooks(deps: SubagentHooksDeps): void {
       asNonEmptyString(eventObj.childSessionKey) ?? asNonEmptyString(ctxObj.childSessionKey);
     if (!childSessionKey) return;
 
-    const host = deps.resolveSubagentHostTrace({ requesterSessionKey, childSessionKey });
+    const existingHost = deps.getSubagentSpanHost(childSessionKey);
+    if (existingHost) {
+      deps.safeSpanEnd(existingHost.span, `subagent reset childSessionKey=${childSessionKey}`);
+      existingHost.active.subagentSpans.delete(childSessionKey);
+      deps.forgetSubagentSpanHost(childSessionKey);
+    }
+
+    const host = deps.resolveSubagentSpanContainer({ requesterSessionKey, childSessionKey });
     if (!host) return;
 
     deps.rememberSessionCorrelation(host.sessionKey);
     host.active.lastActivityAt = Date.now();
 
-    const existing = host.active.subagentSpans.get(childSessionKey);
-    if (existing) {
-      deps.safeSpanEnd(existing, `subagent reset childSessionKey=${childSessionKey}`);
-      host.active.subagentSpans.delete(childSessionKey);
-    }
-
     try {
-      const span = host.active.trace.span({
+      const span = host.parent.span({
         name: `subagent:${asNonEmptyString(eventObj.agentId) ?? "unknown"}`,
         input: {
           childSessionKey,
@@ -67,6 +78,7 @@ export function registerSubagentHooks(deps: SubagentHooksDeps): void {
         },
       });
       host.active.subagentSpans.set(childSessionKey, span);
+      deps.rememberSubagentSpanHost(childSessionKey, host.sessionKey, host.active, span);
     } catch (err) {
       deps.warn(
         `opik: subagent span creation failed (childSessionKey=${childSessionKey}): ${deps.formatError(err)}`,
@@ -85,16 +97,19 @@ export function registerSubagentHooks(deps: SubagentHooksDeps): void {
       asNonEmptyString(eventObj.childSessionKey) ?? asNonEmptyString(ctxObj.childSessionKey);
     if (!childSessionKey) return;
 
-    const host = deps.resolveSubagentHostTrace({ requesterSessionKey, childSessionKey });
+    const existingHost = deps.getSubagentSpanHost(childSessionKey);
+    const host = existingHost
+      ? { sessionKey: existingHost.hostSessionKey, active: existingHost.active, parent: existingHost.span }
+      : deps.resolveSubagentSpanContainer({ requesterSessionKey, childSessionKey });
     if (!host) return;
 
     deps.rememberSessionCorrelation(host.sessionKey);
     host.active.lastActivityAt = Date.now();
 
-    let span = host.active.subagentSpans.get(childSessionKey);
+    let span = existingHost?.span ?? host.active.subagentSpans.get(childSessionKey);
     if (!span) {
       try {
-        span = host.active.trace.span({
+        span = host.parent.span({
           name: `subagent:${asNonEmptyString(eventObj.agentId) ?? "unknown"}`,
           input: {
             childSessionKey,
@@ -103,6 +118,7 @@ export function registerSubagentHooks(deps: SubagentHooksDeps): void {
           },
         });
         host.active.subagentSpans.set(childSessionKey, span);
+        deps.rememberSubagentSpanHost(childSessionKey, host.sessionKey, host.active, span);
       } catch (err) {
         deps.warn(
           `opik: subagent span creation failed on spawn (childSessionKey=${childSessionKey}): ${deps.formatError(err)}`,
@@ -140,16 +156,19 @@ export function registerSubagentHooks(deps: SubagentHooksDeps): void {
       asNonEmptyString(eventObj.childSessionKey) ?? asNonEmptyString(ctxObj.childSessionKey);
     if (!childSessionKey) return;
 
-    const host = deps.resolveSubagentHostTrace({ requesterSessionKey, childSessionKey });
+    const existingHost = deps.getSubagentSpanHost(childSessionKey);
+    const host = existingHost
+      ? { sessionKey: existingHost.hostSessionKey, active: existingHost.active, parent: existingHost.span }
+      : deps.resolveSubagentSpanContainer({ requesterSessionKey, childSessionKey });
     if (!host) return;
 
     deps.rememberSessionCorrelation(host.sessionKey);
     host.active.lastActivityAt = Date.now();
 
-    let span = host.active.subagentSpans.get(childSessionKey);
+    let span = existingHost?.span ?? host.active.subagentSpans.get(childSessionKey);
     if (!span) {
       try {
-        span = host.active.trace.span({
+        span = host.parent.span({
           name: "subagent:delivery-target",
           input: {
             childSessionKey,
@@ -157,6 +176,7 @@ export function registerSubagentHooks(deps: SubagentHooksDeps): void {
           },
         });
         host.active.subagentSpans.set(childSessionKey, span);
+        deps.rememberSubagentSpanHost(childSessionKey, host.sessionKey, host.active, span);
       } catch (err) {
         deps.warn(
           `opik: subagent span creation failed on delivery target (childSessionKey=${childSessionKey}): ${deps.formatError(err)}`,
@@ -210,16 +230,19 @@ export function registerSubagentHooks(deps: SubagentHooksDeps): void {
     const targetSessionKey =
       asNonEmptyString(eventObj.targetSessionKey) ?? childSessionKey;
 
-    const host = deps.resolveSubagentHostTrace({ requesterSessionKey, childSessionKey, targetSessionKey });
+    const existingHost = targetSessionKey ? deps.getSubagentSpanHost(targetSessionKey) : undefined;
+    const host = existingHost
+      ? { sessionKey: existingHost.hostSessionKey, active: existingHost.active, parent: existingHost.span }
+      : deps.resolveSubagentSpanContainer({ requesterSessionKey, childSessionKey, targetSessionKey });
     if (!host) return;
 
     deps.rememberSessionCorrelation(host.sessionKey);
     host.active.lastActivityAt = Date.now();
 
-    let span = targetSessionKey ? host.active.subagentSpans.get(targetSessionKey) : undefined;
+    let span = existingHost?.span ?? (targetSessionKey ? host.active.subagentSpans.get(targetSessionKey) : undefined);
     if (!span) {
       try {
-        span = host.active.trace.span({
+        span = host.parent.span({
           name: `subagent:${asNonEmptyString(eventObj.targetKind) ?? "unknown"}`,
           input: {
             targetSessionKey,
@@ -227,6 +250,10 @@ export function registerSubagentHooks(deps: SubagentHooksDeps): void {
             reason: eventObj.reason,
           },
         });
+        if (targetSessionKey) {
+          host.active.subagentSpans.set(targetSessionKey, span);
+          deps.rememberSubagentSpanHost(targetSessionKey, host.sessionKey, host.active, span);
+        }
       } catch (err) {
         deps.warn(
           `opik: subagent span creation failed on end (targetSessionKey=${targetSessionKey ?? "unknown"}): ${deps.formatError(err)}`,
@@ -270,6 +297,7 @@ export function registerSubagentHooks(deps: SubagentHooksDeps): void {
     deps.safeSpanEnd(span, `subagent_ended targetSessionKey=${targetSessionKey ?? "unknown"}`);
     if (targetSessionKey) {
       host.active.subagentSpans.delete(targetSessionKey);
+      deps.forgetSubagentSpanHost(targetSessionKey);
     }
   });
 }

--- a/src/service/hooks/tool.ts
+++ b/src/service/hooks/tool.ts
@@ -1,5 +1,5 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import type { Opik, Span } from "opik";
+import type { Opik, Span, Trace } from "opik";
 import type { ActiveTrace } from "../../types.js";
 import { asNonEmptyString, resolveRunId, resolveToolCallId } from "../helpers.js";
 import { sanitizeStringForOpik, sanitizeValueForOpik } from "../payload-sanitizer.js";
@@ -11,6 +11,9 @@ type ToolHooksDeps = {
   sessionByAgentId: Map<string, string>;
   getLastActiveSessionKey: () => string | undefined;
   rememberSessionCorrelation: (sessionKey: string, agentId?: unknown) => void;
+  resolveSessionSpanContainer: (
+    sessionKey: string,
+  ) => { sessionKey: string; active: ActiveTrace; parent: Trace | Span } | undefined;
   warnMissingAfterToolSessionKey: (fallbackMode: string) => void;
   nextSpanSeq: () => number;
   safeSpanUpdate: (span: Span, payload: Record<string, unknown>, reason: string) => void;
@@ -34,8 +37,9 @@ export function registerToolHooks(deps: ToolHooksDeps): void {
     if (!sessionKey) return;
     deps.rememberSessionCorrelation(sessionKey, toolCtx.agentId);
 
-    const active = deps.activeTraces.get(sessionKey);
-    if (!active) return;
+    const container = deps.resolveSessionSpanContainer(sessionKey);
+    if (!container) return;
+    const active = container.active;
 
     active.lastActivityAt = Date.now();
 
@@ -54,7 +58,7 @@ export function registerToolHooks(deps: ToolHooksDeps): void {
 
     let toolSpan: Span;
     try {
-      toolSpan = active.trace.span({
+      toolSpan = container.parent.span({
         name: event.toolName,
         type: "tool",
         input: sanitizeValueForOpik(event.params) as any,
@@ -68,8 +72,8 @@ export function registerToolHooks(deps: ToolHooksDeps): void {
     }
 
     const spanKey = toolCallId
-      ? `toolcall:${toolCallId}`
-      : `${event.toolName}:${deps.nextSpanSeq()}`;
+      ? `session:${sessionKey}:toolcall:${toolCallId}`
+      : `session:${sessionKey}:${event.toolName}:${deps.nextSpanSeq()}`;
     if (toolCallId) {
       const existing = active.toolSpans.get(spanKey);
       if (existing) {
@@ -126,15 +130,16 @@ export function registerToolHooks(deps: ToolHooksDeps): void {
     if (!sessionKey) return;
     deps.rememberSessionCorrelation(sessionKey, toolCtx.agentId);
 
-    const active = deps.activeTraces.get(sessionKey);
-    if (!active) return;
+    const container = deps.resolveSessionSpanContainer(sessionKey);
+    if (!container) return;
+    const active = container.active;
 
     active.lastActivityAt = Date.now();
 
     let matchedKey: string | undefined;
     let matchedSpan: Span | undefined;
     if (toolCallId) {
-      const toolCallKey = `toolcall:${toolCallId}`;
+      const toolCallKey = `session:${sessionKey}:toolcall:${toolCallId}`;
       const toolCallSpan = active.toolSpans.get(toolCallKey);
       if (toolCallSpan) {
         matchedKey = toolCallKey;
@@ -143,7 +148,7 @@ export function registerToolHooks(deps: ToolHooksDeps): void {
     }
     if (!matchedSpan) {
       for (const [key, span] of active.toolSpans) {
-        if (key.startsWith(`${event.toolName}:`)) {
+        if (key.startsWith(`session:${sessionKey}:${event.toolName}:`)) {
           matchedKey = key;
           matchedSpan = span;
           break;


### PR DESCRIPTION
## Details
Ensure child-session tool calls and nested subagent spans are created from the active requester subagent span instead of always attaching directly to the root trace.

## Change checklist
- [x] User facing
- [ ] Documentation updated (if needed)
- [x] Tests added/updated (if needed)
- [ ] Breaking changes documented (if any)

## Issues
- Resolves #
- OPIK-

## Testing
- `npm run lint`
- `npm test`
- `npm run smoke`

## Documentation
- Not needed for this internal trace-parenting fix.
