### PR TITLE
fix: restore Opik trace export in embedded runs

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,7 +2,7 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
 import { disableLogger } from "opik";
 import { registerOpikCli } from "./src/configure.js";
-import { createOpikService } from "./src/service.js";
+import { createOpikService, type OpikRuntimeService } from "./src/service.js";
 import { parseOpikPluginConfig } from "./src/types.js";
 
 // Suppress Opik SDK tslog console output
@@ -15,7 +15,9 @@ const plugin = {
   configSchema: emptyPluginConfigSchema(),
   register(api: OpenClawPluginApi) {
     const pluginConfig = parseOpikPluginConfig(api.pluginConfig);
-    api.registerService(createOpikService(api, pluginConfig));
+    const service = createOpikService(api, pluginConfig) as OpikRuntimeService;
+    service.registerHooks();
+    api.registerService(service);
     api.registerCli(
       ({ program }) =>
         registerOpikCli({

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@types/node": "^25.3.3",
+        "commander": "^10.0.1",
         "typescript": "^5.9.3",
         "vitest": "^4.0.18"
       },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.3.3",
+    "commander": "^10.0.1",
     "typescript": "^5.9.3",
     "vitest": "^4.0.18"
   },

--- a/src/plugin.smoke.test.ts
+++ b/src/plugin.smoke.test.ts
@@ -2,15 +2,19 @@ import fs from "node:fs";
 import { Command } from "commander";
 import { describe, expect, test, vi } from "vitest";
 
+const emptyPluginConfigSchema = vi.hoisted(() =>
+  vi.fn(() => ({
+    jsonSchema: { type: "object", additionalProperties: false, properties: {} },
+    parse: (value: unknown) => value,
+  })),
+);
+
 vi.mock("opik", () => ({
   disableLogger: vi.fn(),
 }));
 
 vi.mock("openclaw/plugin-sdk", () => ({
-  emptyPluginConfigSchema: () => ({
-    jsonSchema: { type: "object", additionalProperties: false, properties: {} },
-    parse: (value: unknown) => value,
-  }),
+  emptyPluginConfigSchema,
 }));
 
 import plugin from "../index.js";
@@ -19,9 +23,11 @@ describe("plugin smoke", () => {
   test("registers service and CLI commands", () => {
     const registerService = vi.fn();
     const registerCli = vi.fn();
+    const on = vi.fn();
 
     plugin.register({
       pluginConfig: { enabled: true },
+      on,
       registerService,
       registerCli,
       runtime: {
@@ -34,6 +40,8 @@ describe("plugin smoke", () => {
 
     expect(registerService).toHaveBeenCalledTimes(1);
     expect(registerService.mock.calls[0]?.[0]?.id).toBe("opik-openclaw");
+    expect(on).toHaveBeenCalledWith("llm_input", expect.any(Function));
+    expect(on).toHaveBeenCalledWith("agent_end", expect.any(Function));
 
     expect(registerCli).toHaveBeenCalledTimes(1);
     expect(registerCli.mock.calls[0]?.[1]).toEqual({ commands: ["opik"] });

--- a/src/service.test.ts
+++ b/src/service.test.ts
@@ -166,8 +166,8 @@ describe("opik service", () => {
       const service = createOpikService(api as any);
       await service.start(createServiceContext(false) as any);
 
-      expect(api.on).not.toHaveBeenCalled();
-      expect(Object.keys(hooks)).toHaveLength(0);
+      expect(api.on).toHaveBeenCalledWith("llm_input", expect.any(Function));
+      expect(Object.keys(hooks)).toContain("llm_input");
       expect(mockOpikConstructor).not.toHaveBeenCalled();
     });
 
@@ -301,12 +301,12 @@ describe("opik service", () => {
       );
     });
 
-    test("registers lifecycle/tool/subagent hooks + 1 diagnostic listener on start", async () => {
+    test("registers lifecycle/tool/subagent hooks once and subscribes diagnostics on start", async () => {
       const { api } = createApi();
       const service = createOpikService(api as any);
       await service.start(createServiceContext() as any);
 
-      expect(api.on).toHaveBeenCalledTimes(9);
+      expect(api.on).toHaveBeenCalledTimes(10);
       expect(api.on).toHaveBeenCalledWith("llm_input", expect.any(Function));
       expect(api.on).toHaveBeenCalledWith("llm_output", expect.any(Function));
       expect(api.on).toHaveBeenCalledWith("before_tool_call", expect.any(Function));
@@ -315,7 +315,6 @@ describe("opik service", () => {
       expect(api.on).toHaveBeenCalledWith("subagent_delivery_target", expect.any(Function));
       expect(api.on).toHaveBeenCalledWith("subagent_spawned", expect.any(Function));
       expect(api.on).toHaveBeenCalledWith("subagent_ended", expect.any(Function));
-      expect(api.on).not.toHaveBeenCalledWith("tool_result_persist", expect.any(Function));
       expect(api.on).toHaveBeenCalledWith("agent_end", expect.any(Function));
       expect(diagnosticListeners).toHaveLength(1);
     });
@@ -1737,7 +1736,7 @@ describe("opik service", () => {
       expect(result).toBeUndefined();
     });
 
-    test("is not registered when tool_result_persist sanitization is disabled", async () => {
+    test("returns undefined when tool_result_persist sanitization is disabled", async () => {
       const { api, hooks } = createApi();
       const service = createOpikService(api as any);
       await service.start(
@@ -1748,7 +1747,20 @@ describe("opik service", () => {
         }) as any,
       );
 
-      expect(hooks.tool_result_persist).toBeUndefined();
+      const result = invokeHook(
+        hooks,
+        "tool_result_persist",
+        {
+          toolName: "read_file",
+          message: {
+            role: "tool",
+            content: "preview media:/tmp/image.png",
+          },
+        },
+        { sessionKey: "s1", agentId: "agent-1" },
+      );
+
+      expect(result).toBeUndefined();
     });
   });
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -43,57 +43,109 @@ type ServiceLogger = {
   warn: (message: string) => void;
 };
 
+let client: Opik | null = null;
+const activeTraces = new Map<string, ActiveTrace>();
+const subagentSpanHosts = new Map<
+  string,
+  { hostSessionKey: string; active: ActiveTrace; span: Span }
+>();
+const sessionByAgentId = new Map<string, string>();
+let cleanup: (() => void) | null = null;
+let spanSeq = 0;
+let lastActiveSessionKey: string | undefined;
+let warnedMissingAfterToolSessionKey = false;
+let log: ServiceLogger = {
+  info: () => undefined,
+  warn: () => undefined,
+};
+let staleTraceTimeoutMs = DEFAULT_STALE_TRACE_TIMEOUT_MS;
+let staleSweepIntervalMs = DEFAULT_STALE_SWEEP_INTERVAL_MS;
+let staleTraceCleanupEnabled = true;
+let flushRetryCount = DEFAULT_FLUSH_RETRY_COUNT;
+let flushRetryBaseDelayMs = DEFAULT_FLUSH_RETRY_BASE_DELAY_MS;
+let attachmentBaseUrl = DEFAULT_ATTACHMENT_BASE_URL;
+let currentProjectName = "openclaw";
+let currentTags = ["openclaw"];
+let toolResultPersistSanitizeEnabled = false;
+let flushQueue: Promise<void> = Promise.resolve();
+const attachmentUploader = createAttachmentUploader({
+  getClient: () => client,
+  getAttachmentBaseUrl: () => attachmentBaseUrl,
+  onWarn: (message) => log.warn(message),
+  formatError,
+  attachmentsEnabled: ATTACHMENT_UPLOADS_ENABLED,
+});
+const exporterMetrics = {
+  traceUpdateErrors: 0,
+  traceEndErrors: 0,
+  spanUpdateErrors: 0,
+  spanEndErrors: 0,
+  flushSuccesses: 0,
+  flushFailures: 0,
+  flushRetries: 0,
+};
+
+function resetSharedRuntimeState(): void {
+  cleanup?.();
+  client = null;
+  activeTraces.clear();
+  subagentSpanHosts.clear();
+  sessionByAgentId.clear();
+  cleanup = null;
+  spanSeq = 0;
+  lastActiveSessionKey = undefined;
+  warnedMissingAfterToolSessionKey = false;
+  staleTraceTimeoutMs = DEFAULT_STALE_TRACE_TIMEOUT_MS;
+  staleSweepIntervalMs = DEFAULT_STALE_SWEEP_INTERVAL_MS;
+  staleTraceCleanupEnabled = true;
+  flushRetryCount = DEFAULT_FLUSH_RETRY_COUNT;
+  flushRetryBaseDelayMs = DEFAULT_FLUSH_RETRY_BASE_DELAY_MS;
+  attachmentBaseUrl = DEFAULT_ATTACHMENT_BASE_URL;
+  currentProjectName = "openclaw";
+  currentTags = ["openclaw"];
+  toolResultPersistSanitizeEnabled = false;
+  flushQueue = Promise.resolve();
+  attachmentUploader.reset();
+  exporterMetrics.traceUpdateErrors = 0;
+  exporterMetrics.traceEndErrors = 0;
+  exporterMetrics.spanUpdateErrors = 0;
+  exporterMetrics.spanEndErrors = 0;
+  exporterMetrics.flushSuccesses = 0;
+  exporterMetrics.flushFailures = 0;
+  exporterMetrics.flushRetries = 0;
+}
+
+export type OpikRuntimeService = OpenClawPluginService & {
+  registerHooks: () => void;
+};
+
 export function createOpikService(
   api: OpenClawPluginApi,
   pluginConfig: OpikPluginConfig = {},
-): OpenClawPluginService {
-  let client: Opik | null = null;
-  const activeTraces = new Map<string, ActiveTrace>();
-  const subagentSpanHosts = new Map<
-    string,
-    { hostSessionKey: string; active: ActiveTrace; span: Span }
-  >();
-  const sessionByAgentId = new Map<string, string>();
-  let cleanup: (() => void) | null = null;
-  let spanSeq = 0;
-  let lastActiveSessionKey: string | undefined;
-  let warnedMissingAfterToolSessionKey = false;
-  let log: ServiceLogger = {
-    info: () => undefined,
-    warn: () => undefined,
-  };
-
-  let staleTraceTimeoutMs = DEFAULT_STALE_TRACE_TIMEOUT_MS;
-  let staleSweepIntervalMs = DEFAULT_STALE_SWEEP_INTERVAL_MS;
-  let staleTraceCleanupEnabled = true;
-  let flushRetryCount = DEFAULT_FLUSH_RETRY_COUNT;
-  let flushRetryBaseDelayMs = DEFAULT_FLUSH_RETRY_BASE_DELAY_MS;
-  let attachmentBaseUrl = DEFAULT_ATTACHMENT_BASE_URL;
-
-  let flushQueue: Promise<void> = Promise.resolve();
-  const attachmentUploader = createAttachmentUploader({
-    getClient: () => client,
-    getAttachmentBaseUrl: () => attachmentBaseUrl,
-    onWarn: (message) => log.warn(message),
-    formatError,
-    attachmentsEnabled: ATTACHMENT_UPLOADS_ENABLED,
-  });
-
-  const exporterMetrics = {
-    traceUpdateErrors: 0,
-    traceEndErrors: 0,
-    spanUpdateErrors: 0,
-    spanEndErrors: 0,
-    flushSuccesses: 0,
-    flushFailures: 0,
-    flushRetries: 0,
-  };
+): OpikRuntimeService {
+  let hooksRegistered = false;
 
   function rememberSessionCorrelation(sessionKey: string, agentId?: unknown): void {
     lastActiveSessionKey = sessionKey;
     if (typeof agentId === "string" && agentId.length > 0) {
       sessionByAgentId.set(agentId, sessionKey);
     }
+  }
+
+  function resolveSessionKey(ctx: Record<string, unknown>): string | undefined {
+    const explicitSessionKey = asNonEmptyString(ctx.sessionKey);
+    if (explicitSessionKey) return explicitSessionKey;
+
+    const sessionId = asNonEmptyString(ctx.sessionId);
+    if (sessionId) return sessionId;
+
+    const agentId = asNonEmptyString(ctx.agentId);
+    if (agentId) {
+      const mappedSessionKey = sessionByAgentId.get(agentId);
+      if (mappedSessionKey) return mappedSessionKey;
+    }
+
+    return lastActiveSessionKey;
   }
 
   function applyContextMeta(active: ActiveTrace, ctx: Record<string, unknown>): void {
@@ -427,14 +479,153 @@ export function createOpikService(
     scheduleFlush(`trace-finalized sessionKey=${sessionKey}`);
   }
 
-  return {
+  function registerHooks(): void {
+    if (hooksRegistered) {
+      return;
+    }
+    hooksRegistered = true;
+
+    registerLlmHooks({
+      api,
+      getClient: () => client,
+      activeTraces,
+      getTags: () => currentTags,
+      getProjectName: () => currentProjectName,
+      rememberSessionCorrelation,
+      closeActiveTrace,
+      forgetSessionCorrelation,
+      applyContextMeta,
+      safeSpanUpdate,
+      safeSpanEnd,
+      scheduleMediaAttachmentUploads: attachmentUploader.scheduleMediaAttachmentUploads,
+      warn: (message) => log.warn(message),
+      formatError,
+      resolveSessionKey,
+    });
+
+    registerToolHooks({
+      api,
+      getClient: () => client,
+      activeTraces,
+      sessionByAgentId,
+      getLastActiveSessionKey: () => lastActiveSessionKey,
+      rememberSessionCorrelation,
+      resolveSessionSpanContainer,
+      warnMissingAfterToolSessionKey,
+      nextSpanSeq: () => ++spanSeq,
+      safeSpanUpdate,
+      safeSpanEnd,
+      scheduleMediaAttachmentUploads: attachmentUploader.scheduleMediaAttachmentUploads,
+      getProjectName: () => currentProjectName,
+      warn: (message) => log.warn(message),
+      formatError,
+    });
+
+    registerSubagentHooks({
+      api,
+      getClient: () => client,
+      rememberSessionCorrelation,
+      resolveSubagentSpanContainer,
+      getSubagentSpanHost,
+      rememberSubagentSpanHost,
+      forgetSubagentSpanHost,
+      safeSpanUpdate,
+      safeSpanEnd,
+      warn: (message) => log.warn(message),
+      formatError,
+    });
+
+    api.on("tool_result_persist", (event) => {
+      if (!toolResultPersistSanitizeEnabled) {
+        return;
+      }
+
+      try {
+        const eventObj = event as Record<string, unknown>;
+        const message = eventObj.message;
+        if (!message || typeof message !== "object") return;
+
+        const sanitizedMessage = sanitizeValueForOpik(message);
+        if (sanitizedMessage !== message) {
+          return { message: sanitizedMessage };
+        }
+      } catch (err) {
+        log.warn(`opik: tool_result_persist failed: ${formatError(err)}`);
+      }
+    });
+
+    api.on("agent_end", (event, agentCtx) => {
+      const agentCtxObj = agentCtx as Record<string, unknown>;
+      const sessionKey = resolveSessionKey(agentCtxObj);
+      if (!sessionKey) {
+        log.warn("opik: agent_end missing sessionKey");
+        return;
+      }
+      rememberSessionCorrelation(sessionKey, agentCtx.agentId);
+
+      const active = activeTraces.get(sessionKey);
+      if (!active) {
+        log.warn(
+          `opik: agent_end missing active trace sessionKey=${sessionKey} activeTraces=${activeTraces.size}`,
+        );
+        return;
+      }
+
+      applyContextMeta(active, agentCtx as Record<string, unknown>);
+      for (const [toolKey, toolSpan] of active.toolSpans) {
+        safeSpanEnd(toolSpan, `agent_end orphan tool sessionKey=${sessionKey} toolKey=${toolKey}`);
+      }
+      active.toolSpans.clear();
+
+      for (const [subagentKey, subagentSpan] of active.subagentSpans) {
+        safeSpanEnd(
+          subagentSpan,
+          `agent_end orphan subagent sessionKey=${sessionKey} subagentKey=${subagentKey}`,
+        );
+      }
+      active.subagentSpans.clear();
+
+      active.agentEnd = {
+        success: event.success,
+        error: typeof event.error === "string" ? sanitizeStringForOpik(event.error) : event.error,
+        durationMs: event.durationMs,
+        messages: (sanitizeValueForOpik(
+          ((event as Record<string, unknown>).messages as unknown[]) ?? [],
+        ) as unknown[]) ?? [],
+      };
+
+      attachmentUploader.scheduleMediaAttachmentUploads({
+        entityType: "trace",
+        entity: active.trace,
+        projectName: currentProjectName,
+        reason: `agent_end sessionKey=${sessionKey}`,
+        payloads: [
+          event.error,
+          ((event as Record<string, unknown>).messages as unknown[] | undefined)?.at(-1),
+        ],
+      });
+
+      const traceRef = active.trace;
+      queueMicrotask(() => {
+        const current = activeTraces.get(sessionKey);
+        if (current && current.trace === traceRef) finalizeTrace(sessionKey);
+      });
+    });
+  }
+
+  const service: OpikRuntimeService = {
     id: OPIK_PLUGIN_ID,
+    registerHooks,
     async start(ctx) {
+      registerHooks();
+      resetSharedRuntimeState();
       log = {
         info: ctx.logger.info.bind(ctx.logger),
         warn: ctx.logger.warn.bind(ctx.logger),
       };
-      attachmentUploader.reset();
+      currentProjectName = pluginConfig.projectName?.trim() || "openclaw";
+      currentTags = pluginConfig.tags ?? ["openclaw"];
+      toolResultPersistSanitizeEnabled = pluginConfig.toolResultPersistSanitizeEnabled === true;
 
       const runtimeCfg = parseOpikPluginConfig(ctx.config);
       const opikCfg = mergeDefinedConfig(runtimeCfg, pluginConfig);
@@ -449,7 +640,10 @@ export function createOpikService(
       const workspaceName =
         opikCfg.workspaceName ?? trimOrUndefined(process.env.OPIK_WORKSPACE) ?? "default";
       const tags = opikCfg.tags ?? ["openclaw"];
+      currentProjectName = projectName;
+      currentTags = tags;
       attachmentBaseUrl = (apiUrl ?? DEFAULT_ATTACHMENT_BASE_URL).replace(/\/+$/, "");
+      toolResultPersistSanitizeEnabled = opikCfg.toolResultPersistSanitizeEnabled === true;
 
       staleTraceCleanupEnabled = opikCfg.staleTraceCleanupEnabled !== false;
       staleTraceTimeoutMs = Math.max(
@@ -477,131 +671,6 @@ export function createOpikService(
         client,
         projectName,
         workspaceName,
-      });
-
-      registerLlmHooks({
-        api,
-        getClient: () => client,
-        activeTraces,
-        tags,
-        projectName,
-        rememberSessionCorrelation,
-        closeActiveTrace,
-        forgetSessionCorrelation,
-        applyContextMeta,
-        safeSpanUpdate,
-        safeSpanEnd,
-        scheduleMediaAttachmentUploads: attachmentUploader.scheduleMediaAttachmentUploads,
-        warn: (message) => log.warn(message),
-        formatError,
-      });
-
-      registerToolHooks({
-        api,
-        getClient: () => client,
-        activeTraces,
-        sessionByAgentId,
-        getLastActiveSessionKey: () => lastActiveSessionKey,
-        rememberSessionCorrelation,
-        resolveSessionSpanContainer,
-        warnMissingAfterToolSessionKey,
-        nextSpanSeq: () => ++spanSeq,
-        safeSpanUpdate,
-        safeSpanEnd,
-        scheduleMediaAttachmentUploads: attachmentUploader.scheduleMediaAttachmentUploads,
-        projectName,
-        warn: (message) => log.warn(message),
-        formatError,
-      });
-
-      registerSubagentHooks({
-        api,
-        getClient: () => client,
-        rememberSessionCorrelation,
-        resolveSubagentSpanContainer,
-        getSubagentSpanHost,
-        rememberSubagentSpanHost,
-        forgetSubagentSpanHost,
-        safeSpanUpdate,
-        safeSpanEnd,
-        warn: (message) => log.warn(message),
-        formatError,
-      });
-
-      // =====================================================================
-      // Hook: tool_result_persist — sanitize persisted tool messages (opt-in)
-      // =====================================================================
-      if (opikCfg.toolResultPersistSanitizeEnabled === true) {
-        api.on("tool_result_persist", (event) => {
-          try {
-            const eventObj = event as Record<string, unknown>;
-            const message = eventObj.message;
-            if (!message || typeof message !== "object") return;
-
-            const sanitizedMessage = sanitizeValueForOpik(message);
-            if (sanitizedMessage !== message) {
-              return { message: sanitizedMessage };
-            }
-          } catch (err) {
-            log.warn(`opik: tool_result_persist failed: ${formatError(err)}`);
-          }
-        });
-      }
-
-      // =====================================================================
-      // Hook: agent_end — Finalize Trace
-      // =====================================================================
-      api.on("agent_end", (event, agentCtx) => {
-        const sessionKey = agentCtx.sessionKey;
-        if (!sessionKey) return;
-        rememberSessionCorrelation(sessionKey, agentCtx.agentId);
-
-        const active = activeTraces.get(sessionKey);
-        if (!active) return;
-
-        applyContextMeta(active, agentCtx as Record<string, unknown>);
-        // Close any orphaned tool/subagent spans synchronously.
-        for (const [toolKey, toolSpan] of active.toolSpans) {
-          safeSpanEnd(toolSpan, `agent_end orphan tool sessionKey=${sessionKey} toolKey=${toolKey}`);
-        }
-        active.toolSpans.clear();
-
-        for (const [subagentKey, subagentSpan] of active.subagentSpans) {
-          safeSpanEnd(
-            subagentSpan,
-            `agent_end orphan subagent sessionKey=${sessionKey} subagentKey=${subagentKey}`,
-          );
-        }
-        active.subagentSpans.clear();
-
-        // Store agent-end data for deferred finalization.
-        active.agentEnd = {
-          success: event.success,
-          error: typeof event.error === "string" ? sanitizeStringForOpik(event.error) : event.error,
-          durationMs: event.durationMs,
-          messages: (sanitizeValueForOpik(
-            ((event as Record<string, unknown>).messages as unknown[]) ?? [],
-          ) as unknown[]) ?? [],
-        };
-
-        attachmentUploader.scheduleMediaAttachmentUploads({
-          entityType: "trace",
-          entity: active.trace,
-          projectName,
-          reason: `agent_end sessionKey=${sessionKey}`,
-          payloads: [
-            event.error,
-            ((event as Record<string, unknown>).messages as unknown[] | undefined)?.at(-1),
-          ],
-        });
-
-        // Defer finalization to a microtask so llm_output (which fires on the
-        // same synchronous call stack) can store output/usage first.
-        const traceRef = active.trace;
-        queueMicrotask(() => {
-          const current = activeTraces.get(sessionKey);
-          if (current && current.trace === traceRef) finalizeTrace(sessionKey);
-        });
       });
 
       // =====================================================================
@@ -711,10 +780,13 @@ export function createOpikService(
         await flushWithRetry("service stop");
         client = null;
       }
+      toolResultPersistSanitizeEnabled = false;
 
       log.info(
         `opik: exporter metrics flushSuccesses=${exporterMetrics.flushSuccesses} flushFailures=${exporterMetrics.flushFailures} flushRetries=${exporterMetrics.flushRetries} traceUpdateErrors=${exporterMetrics.traceUpdateErrors} traceEndErrors=${exporterMetrics.traceEndErrors} spanUpdateErrors=${exporterMetrics.spanUpdateErrors} spanEndErrors=${exporterMetrics.spanEndErrors}`,
       );
     },
-  } satisfies OpenClawPluginService;
+  };
+
+  return service;
 }

--- a/src/service/hooks/llm.ts
+++ b/src/service/hooks/llm.ts
@@ -3,6 +3,7 @@ import type { Opik, Span, Trace } from "opik";
 import type { ActiveTrace } from "../../types.js";
 import { OPIK_CREATED_FROM } from "../constants.js";
 import {
+  asNonEmptyString,
   mapUsageToOpikTokens,
   normalizeProvider,
   resolveChannelId,
@@ -14,12 +15,13 @@ type LlmHooksDeps = {
   api: OpenClawPluginApi;
   getClient: () => Opik | null;
   activeTraces: Map<string, ActiveTrace>;
-  tags: string[];
-  projectName: string;
+  getTags: () => string[];
+  getProjectName: () => string;
   rememberSessionCorrelation: (sessionKey: string, agentId?: unknown) => void;
   closeActiveTrace: (active: ActiveTrace, reason: string) => void;
   forgetSessionCorrelation: (sessionKey: string) => void;
   applyContextMeta: (active: ActiveTrace, ctx: Record<string, unknown>) => void;
+  resolveSessionKey: (ctx: Record<string, unknown>) => string | undefined;
   safeSpanUpdate: (span: Span, payload: Record<string, unknown>, reason: string) => void;
   safeSpanEnd: (span: Span, reason: string) => void;
   scheduleMediaAttachmentUploads: (params: {
@@ -36,12 +38,18 @@ type LlmHooksDeps = {
 export function registerLlmHooks(deps: LlmHooksDeps): void {
   deps.api.on("llm_input", (event, agentCtx) => {
     const client = deps.getClient();
+    const agentCtxObj = agentCtx as Record<string, unknown>;
+    const sessionKey = deps.resolveSessionKey({
+      ...agentCtxObj,
+      sessionId: asNonEmptyString(event.sessionId) ?? agentCtxObj.sessionId,
+    });
     if (!client) return;
-    const sessionKey = agentCtx.sessionKey;
-    if (!sessionKey) return;
+    if (!sessionKey) {
+      deps.warn("opik: llm_input missing sessionKey");
+      return;
+    }
     deps.rememberSessionCorrelation(sessionKey, agentCtx.agentId);
     const normalizedProvider = normalizeProvider(event.provider) ?? event.provider;
-    const agentCtxObj = agentCtx as Record<string, unknown>;
     const channelId = resolveChannelId(agentCtxObj);
     const trigger = resolveTrigger(agentCtxObj);
 
@@ -73,7 +81,7 @@ export function registerLlmHooks(deps: LlmHooksDeps): void {
           ...(channelId ? { channel: channelId, channelId } : {}),
           ...(trigger ? { trigger } : {}),
         },
-        tags: deps.tags.length > 0 ? deps.tags : undefined,
+        tags: deps.getTags().length > 0 ? deps.getTags() : undefined,
       });
     } catch (err) {
       deps.warn(`opik: trace creation failed (sessionKey=${sessionKey}): ${deps.formatError(err)}`);
@@ -118,21 +126,31 @@ export function registerLlmHooks(deps: LlmHooksDeps): void {
     deps.scheduleMediaAttachmentUploads({
       entityType: "trace",
       entity: trace,
-      projectName: deps.projectName,
+      projectName: deps.getProjectName(),
       reason: `llm_input sessionKey=${sessionKey}`,
       payloads: [event.prompt, Array.isArray(event.historyMessages) ? event.historyMessages.at(-1) : undefined],
     });
   });
 
   deps.api.on("llm_output", (event, agentCtx) => {
-    if (!deps.getClient()) return;
-    const sessionKey = agentCtx.sessionKey;
-    if (!sessionKey) return;
+    const client = deps.getClient();
+    const agentCtxObj = agentCtx as Record<string, unknown>;
+    const sessionKey = deps.resolveSessionKey(agentCtxObj);
+    if (!client) return;
+    if (!sessionKey) {
+      deps.warn("opik: llm_output missing sessionKey");
+      return;
+    }
     deps.rememberSessionCorrelation(sessionKey, agentCtx.agentId);
     const normalizedProvider = normalizeProvider(event.provider) ?? event.provider;
 
     const active = deps.activeTraces.get(sessionKey);
-    if (!active?.llmSpan) return;
+    if (!active?.llmSpan) {
+      deps.warn(
+        `opik: llm_output missing active llm span sessionKey=${sessionKey} hasTrace=${Boolean(active)} hasLlmSpan=${Boolean(active?.llmSpan)}`,
+      );
+      return;
+    }
 
     deps.applyContextMeta(active, agentCtx as Record<string, unknown>);
     active.lastActivityAt = Date.now();

--- a/src/service/hooks/tool.ts
+++ b/src/service/hooks/tool.ts
@@ -25,7 +25,7 @@ type ToolHooksDeps = {
     reason: string;
     payloads: unknown[];
   }) => void;
-  projectName: string;
+  getProjectName: () => string;
   warn: (message: string) => void;
   formatError: (err: unknown) => string;
 };
@@ -89,7 +89,7 @@ export function registerToolHooks(deps: ToolHooksDeps): void {
     deps.scheduleMediaAttachmentUploads({
       entityType: "span",
       entity: toolSpan,
-      projectName: deps.projectName,
+      projectName: deps.getProjectName(),
       reason: `before_tool_call sessionKey=${sessionKey} tool=${event.toolName}`,
       payloads: [event.params],
     });
@@ -199,7 +199,7 @@ export function registerToolHooks(deps: ToolHooksDeps): void {
     deps.scheduleMediaAttachmentUploads({
       entityType: "span",
       entity: matchedSpan,
-      projectName: deps.projectName,
+      projectName: deps.getProjectName(),
       reason: `after_tool_call sessionKey=${sessionKey} tool=${event.toolName}`,
       payloads: [event.params, event.result, event.error],
     });


### PR DESCRIPTION
## Problem

This is a regression fix.

Opik tracing used to work, but stopped working after OpenClaw's newer plugin lifecycle/architecture changes. The Opik plugin was still following the older assumptions about when hooks are registered, which instance owns runtime state, and which session identifier is always present in hook context.

In practice the plugin could still start and log:

`opik: exporting traces to project ...`

but no traces or spans were actually exported during live OpenClaw gateway runs.

## What changed in OpenClaw

The newer plugin architecture made two assumptions unsafe:

1. Registering hooks during `service.start()`
2. Keeping exporter runtime state inside one service-instance closure

In the newer lifecycle, those assumptions no longer hold consistently:

- hook registration can happen on a different path/timing than service startup
- hook callbacks and `service.start()` may not be operating on the same service instance
- some live runs can fire hooks without `agentCtx.sessionKey`, even though `sessionId` is still available

The Opik plugin had not been updated to match those newer lifecycle details.

## Actual failure mode

The breakage was not just one bug. It was a chain:

1. Hooks were being registered too late in the lifecycle.
2. The hook callbacks and `service.start()` were not sharing the same runtime state.
3. In the Nebius live gateway path, hooks could fire without `agentCtx.sessionKey`, even though `sessionId` remained stable.

That combination meant:

- the plugin looked healthy at startup
- hooks could appear wired
- but trace creation/finalization still no-op'd in real gateway runs

## Fix

This PR updates the Opik plugin to match the newer OpenClaw plugin architecture.

### 1. Register hooks during plugin registration

`index.ts` now:

- creates the service
- calls `service.registerHooks()`
- then registers the service with OpenClaw

This moves hook registration to plugin registration time instead of waiting for `service.start()`.

### 2. Share exporter runtime state across instances

`src/service.ts` now keeps mutable exporter state at module scope instead of inside a single service-instance closure:

- Opik client
- active trace/span maps
- session/subagent correlation maps
- flush queue
- runtime config state

This ensures the hook callbacks and `service.start()` use the same exporter state even when OpenClaw creates different service instances along the way.

### 3. Fall back when `sessionKey` is missing

When `agentCtx.sessionKey` is missing, the plugin now resolves a session key in this order:

1. `agentCtx.sessionKey`
2. `agentCtx.sessionId`
3. remembered `agentId -> sessionKey`
4. last active session key

This is what restores tracing for the Nebius live gateway baseline path.

## Why this is broader than a reload-only fix

The earlier diagnosis around registry reloads and split hook state was directionally correct, but incomplete.

Even after fixing the shared-state / early-registration issue, tracing still did not work in the live gateway baseline until the plugin also handled missing `sessionKey`.

So this PR is intended to fix all of the following under the newer OpenClaw plugin architecture:

- lifecycle timing issues
- split runtime state across service instances
- missing session correlation in live gateway runs

## Validation

### Local checks

- `npm run typecheck`
- `npm test` (`98 passed, 1 skipped`)

### End-to-end verification

Verified with the OpenClawMachines Nebius baseline harness using the locally bundled plugin tarball.

Final result:

- `mock_status={"traces":1,"spans":1}`

Observed mock traffic included:

- `POST /v1/private/traces/batch`
- `POST /v1/private/spans/batch`
- `PATCH /v1/private/traces/...`
- `PATCH /v1/private/spans/...`

The Nebius model request still failed with a network connection error during the harness run, but the important result is that Opik trace export now fires end to end again.
