### PR TITLE
Register tracing hooks before service start

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -15,7 +15,11 @@ const plugin = {
   configSchema: emptyPluginConfigSchema(),
   register(api: OpenClawPluginApi) {
     const pluginConfig = parseOpikPluginConfig(api.pluginConfig);
-    api.registerService(createOpikService(api, pluginConfig));
+    api.registerService(
+      createOpikService(api, pluginConfig, {
+        registerHooksImmediately: true,
+      }),
+    );
     api.registerCli(
       ({ program }) =>
         registerOpikCli({

--- a/src/plugin.smoke.test.ts
+++ b/src/plugin.smoke.test.ts
@@ -19,9 +19,11 @@ describe("plugin smoke", () => {
   test("registers service and CLI commands", () => {
     const registerService = vi.fn();
     const registerCli = vi.fn();
+    const on = vi.fn();
 
     plugin.register({
       pluginConfig: { enabled: true },
+      on,
       registerService,
       registerCli,
       runtime: {
@@ -37,6 +39,17 @@ describe("plugin smoke", () => {
 
     expect(registerCli).toHaveBeenCalledTimes(1);
     expect(registerCli.mock.calls[0]?.[1]).toEqual({ commands: ["opik"] });
+
+    expect(on).toHaveBeenCalledWith("llm_input", expect.any(Function));
+    expect(on).toHaveBeenCalledWith("llm_output", expect.any(Function));
+    expect(on).toHaveBeenCalledWith("before_tool_call", expect.any(Function));
+    expect(on).toHaveBeenCalledWith("after_tool_call", expect.any(Function));
+    expect(on).toHaveBeenCalledWith("subagent_spawning", expect.any(Function));
+    expect(on).toHaveBeenCalledWith("subagent_delivery_target", expect.any(Function));
+    expect(on).toHaveBeenCalledWith("subagent_spawned", expect.any(Function));
+    expect(on).toHaveBeenCalledWith("subagent_ended", expect.any(Function));
+    expect(on).toHaveBeenCalledWith("tool_result_persist", expect.any(Function));
+    expect(on).toHaveBeenCalledWith("agent_end", expect.any(Function));
 
     const registrar = registerCli.mock.calls[0]?.[0];
     const program = new Command();

--- a/src/service.test.ts
+++ b/src/service.test.ts
@@ -306,7 +306,7 @@ describe("opik service", () => {
       const service = createOpikService(api as any);
       await service.start(createServiceContext() as any);
 
-      expect(api.on).toHaveBeenCalledTimes(9);
+      expect(api.on).toHaveBeenCalledTimes(10);
       expect(api.on).toHaveBeenCalledWith("llm_input", expect.any(Function));
       expect(api.on).toHaveBeenCalledWith("llm_output", expect.any(Function));
       expect(api.on).toHaveBeenCalledWith("before_tool_call", expect.any(Function));
@@ -315,7 +315,7 @@ describe("opik service", () => {
       expect(api.on).toHaveBeenCalledWith("subagent_delivery_target", expect.any(Function));
       expect(api.on).toHaveBeenCalledWith("subagent_spawned", expect.any(Function));
       expect(api.on).toHaveBeenCalledWith("subagent_ended", expect.any(Function));
-      expect(api.on).not.toHaveBeenCalledWith("tool_result_persist", expect.any(Function));
+      expect(api.on).toHaveBeenCalledWith("tool_result_persist", expect.any(Function));
       expect(api.on).toHaveBeenCalledWith("agent_end", expect.any(Function));
       expect(diagnosticListeners).toHaveLength(1);
     });
@@ -376,18 +376,69 @@ describe("opik service", () => {
       expect(api.on).toHaveBeenCalledWith("llm_input", expect.any(Function));
     });
 
-    test("registers tool_result_persist hook only when enabled", async () => {
+    test("can register hooks immediately for runtime compatibility", () => {
       const { api } = createApi();
-      const service = createOpikService(api as any);
-      await service.start(
-        createServiceContext(true, {
+      createOpikService(api as any, {}, { registerHooksImmediately: true });
+
+      expect(api.on).toHaveBeenCalledWith("llm_input", expect.any(Function));
+      expect(api.on).toHaveBeenCalledWith("llm_output", expect.any(Function));
+      expect(api.on).toHaveBeenCalledWith("before_tool_call", expect.any(Function));
+      expect(api.on).toHaveBeenCalledWith("after_tool_call", expect.any(Function));
+      expect(api.on).toHaveBeenCalledWith("subagent_spawning", expect.any(Function));
+      expect(api.on).toHaveBeenCalledWith("subagent_delivery_target", expect.any(Function));
+      expect(api.on).toHaveBeenCalledWith("subagent_spawned", expect.any(Function));
+      expect(api.on).toHaveBeenCalledWith("subagent_ended", expect.any(Function));
+      expect(api.on).toHaveBeenCalledWith("tool_result_persist", expect.any(Function));
+      expect(api.on).toHaveBeenCalledWith("agent_end", expect.any(Function));
+    });
+
+    test("lazily initializes the Opik client for immediate hook registration", () => {
+      const { api, hooks } = createApi();
+      const mockTrace = opikState.createMockTrace();
+      mockTraceFn.mockReturnValue(mockTrace);
+
+      createOpikService(
+        api as any,
+        {
           enabled: true,
-          apiKey: "test-key",
-          toolResultPersistSanitizeEnabled: true,
-        }) as any,
+          apiKey: "lazy-key",
+          projectName: "lazy-project",
+          workspaceName: "lazy-workspace",
+        },
+        { registerHooksImmediately: true },
       );
 
-      expect(api.on).toHaveBeenCalledWith("tool_result_persist", expect.any(Function));
+      invokeHook(
+        hooks,
+        "llm_input",
+        { model: "m", provider: "p", prompt: "hello", historyMessages: [] },
+        agentCtx("session-lazy"),
+      );
+
+      expect(mockOpikConstructor).toHaveBeenCalledWith({
+        apiKey: "lazy-key",
+        projectName: "lazy-project",
+        workspaceName: "lazy-workspace",
+      });
+      expect(mockTraceFn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          threadId: "session-lazy",
+        }),
+      );
+    });
+
+    test("returns undefined from tool_result_persist when sanitizing is disabled", async () => {
+      const { api } = createApi();
+      const hooks = new Map<string, Function>();
+      api.on.mockImplementation((name: string, handler: Function) => {
+        hooks.set(name, handler);
+      });
+      const service = createOpikService(api as any);
+      await service.start(createServiceContext(true, { enabled: true, apiKey: "test-key" }) as any);
+
+      const toolResultPersist = hooks.get("tool_result_persist");
+      expect(toolResultPersist).toEqual(expect.any(Function));
+      expect(toolResultPersist?.({ message: { role: "tool", content: "ok" } })).toBeUndefined();
     });
   });
 
@@ -1737,7 +1788,7 @@ describe("opik service", () => {
       expect(result).toBeUndefined();
     });
 
-    test("is not registered when tool_result_persist sanitization is disabled", async () => {
+    test("returns undefined when tool_result_persist sanitization is disabled", async () => {
       const { api, hooks } = createApi();
       const service = createOpikService(api as any);
       await service.start(
@@ -1748,7 +1799,18 @@ describe("opik service", () => {
         }) as any,
       );
 
-      expect(hooks.tool_result_persist).toBeUndefined();
+      expect(hooks.tool_result_persist).toEqual(expect.any(Function));
+      expect(
+        hooks.tool_result_persist?.(
+          {
+            message: {
+              role: "tool",
+              content: "plain text",
+            },
+          },
+          { sessionKey: "s1", agentId: "agent-1" },
+        ),
+      ).toBeUndefined();
     });
   });
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -43,9 +43,14 @@ type ServiceLogger = {
   warn: (message: string) => void;
 };
 
+type CreateOpikServiceOptions = {
+  registerHooksImmediately?: boolean;
+};
+
 export function createOpikService(
   api: OpenClawPluginApi,
   pluginConfig: OpikPluginConfig = {},
+  options: CreateOpikServiceOptions = {},
 ): OpenClawPluginService {
   let client: Opik | null = null;
   const activeTraces = new Map<string, ActiveTrace>();
@@ -69,6 +74,15 @@ export function createOpikService(
   let flushRetryCount = DEFAULT_FLUSH_RETRY_COUNT;
   let flushRetryBaseDelayMs = DEFAULT_FLUSH_RETRY_BASE_DELAY_MS;
   let attachmentBaseUrl = DEFAULT_ATTACHMENT_BASE_URL;
+  let currentEnabled = pluginConfig.enabled === true;
+  let currentApiKey = pluginConfig.apiKey ?? process.env.OPIK_API_KEY;
+  let currentApiUrl = pluginConfig.apiUrl ?? process.env.OPIK_URL_OVERRIDE;
+  let currentProjectName = pluginConfig.projectName ?? "openclaw";
+  let currentWorkspaceName =
+    pluginConfig.workspaceName ?? trimOrUndefined(process.env.OPIK_WORKSPACE) ?? "default";
+  let currentTags = pluginConfig.tags ?? ["openclaw"];
+  let toolResultPersistSanitizeEnabled = pluginConfig.toolResultPersistSanitizeEnabled === true;
+  let hooksRegistered = false;
 
   let flushQueue: Promise<void> = Promise.resolve();
   const attachmentUploader = createAttachmentUploader({
@@ -117,6 +131,150 @@ export function createOpikService(
         sessionByAgentId.delete(agentId);
       }
     }
+  }
+
+  function registerPluginHooks(): void {
+    if (hooksRegistered) {
+      return;
+    }
+    hooksRegistered = true;
+
+    registerLlmHooks({
+      api,
+      getClient: ensureClient,
+      activeTraces,
+      getTags: () => currentTags,
+      getProjectName: () => currentProjectName,
+      rememberSessionCorrelation,
+      closeActiveTrace,
+      forgetSessionCorrelation,
+      applyContextMeta,
+      safeSpanUpdate,
+      safeSpanEnd,
+      scheduleMediaAttachmentUploads: attachmentUploader.scheduleMediaAttachmentUploads,
+      warn: (message) => log.warn(message),
+      formatError,
+    });
+
+    registerToolHooks({
+      api,
+      getClient: ensureClient,
+      activeTraces,
+      sessionByAgentId,
+      getLastActiveSessionKey: () => lastActiveSessionKey,
+      rememberSessionCorrelation,
+      resolveSessionSpanContainer,
+      warnMissingAfterToolSessionKey,
+      nextSpanSeq: () => ++spanSeq,
+      safeSpanUpdate,
+      safeSpanEnd,
+      scheduleMediaAttachmentUploads: attachmentUploader.scheduleMediaAttachmentUploads,
+      getProjectName: () => currentProjectName,
+      warn: (message) => log.warn(message),
+      formatError,
+    });
+
+    registerSubagentHooks({
+      api,
+      getClient: ensureClient,
+      rememberSessionCorrelation,
+      resolveSubagentSpanContainer,
+      getSubagentSpanHost,
+      rememberSubagentSpanHost,
+      forgetSubagentSpanHost,
+      safeSpanUpdate,
+      safeSpanEnd,
+      warn: (message) => log.warn(message),
+      formatError,
+    });
+
+    api.on("tool_result_persist", (event) => {
+      if (toolResultPersistSanitizeEnabled !== true) {
+        return;
+      }
+      try {
+        const eventObj = event as Record<string, unknown>;
+        const message = eventObj.message;
+        if (!message || typeof message !== "object") return;
+
+        const sanitizedMessage = sanitizeValueForOpik(message);
+        if (sanitizedMessage !== message) {
+          return { message: sanitizedMessage };
+        }
+      } catch (err) {
+        log.warn(`opik: tool_result_persist failed: ${formatError(err)}`);
+      }
+    });
+
+    api.on("agent_end", (event, agentCtx) => {
+      const sessionKey = agentCtx.sessionKey;
+      if (!sessionKey) return;
+      rememberSessionCorrelation(sessionKey, agentCtx.agentId);
+
+      const active = activeTraces.get(sessionKey);
+      if (!active) return;
+
+      applyContextMeta(active, agentCtx as Record<string, unknown>);
+      for (const [toolKey, toolSpan] of active.toolSpans) {
+        safeSpanEnd(toolSpan, `agent_end orphan tool sessionKey=${sessionKey} toolKey=${toolKey}`);
+      }
+      active.toolSpans.clear();
+
+      for (const [subagentKey, subagentSpan] of active.subagentSpans) {
+        safeSpanEnd(
+          subagentSpan,
+          `agent_end orphan subagent sessionKey=${sessionKey} subagentKey=${subagentKey}`,
+        );
+      }
+      active.subagentSpans.clear();
+
+      active.agentEnd = {
+        success: event.success,
+        error: typeof event.error === "string" ? sanitizeStringForOpik(event.error) : event.error,
+        durationMs: event.durationMs,
+        messages: (sanitizeValueForOpik(
+          ((event as Record<string, unknown>).messages as unknown[]) ?? [],
+        ) as unknown[]) ?? [],
+      };
+
+      attachmentUploader.scheduleMediaAttachmentUploads({
+        entityType: "trace",
+        entity: active.trace,
+        projectName: currentProjectName,
+        reason: `agent_end sessionKey=${sessionKey}`,
+        payloads: [
+          event.error,
+          ((event as Record<string, unknown>).messages as unknown[] | undefined)?.at(-1),
+        ],
+      });
+
+      const traceRef = active.trace;
+      queueMicrotask(() => {
+        const current = activeTraces.get(sessionKey);
+        if (current && current.trace === traceRef) finalizeTrace(sessionKey);
+      });
+    });
+  }
+
+  if (options.registerHooksImmediately) {
+    registerPluginHooks();
+  }
+
+  function ensureClient(): Opik | null {
+    if (!currentEnabled) {
+      return null;
+    }
+    if (client) {
+      return client;
+    }
+
+    client = new Opik({
+      apiKey: currentApiKey,
+      ...(currentApiUrl ? { apiUrl: currentApiUrl } : {}),
+      projectName: currentProjectName,
+      workspaceName: currentWorkspaceName,
+    });
+    return client;
   }
 
   function rememberSubagentSpanHost(
@@ -439,17 +597,22 @@ export function createOpikService(
       const runtimeCfg = parseOpikPluginConfig(ctx.config);
       const opikCfg = mergeDefinedConfig(runtimeCfg, pluginConfig);
 
-      if (!opikCfg?.enabled) {
+      currentEnabled = opikCfg.enabled === true;
+      currentApiKey = opikCfg.apiKey ?? process.env.OPIK_API_KEY;
+      currentApiUrl = opikCfg.apiUrl ?? process.env.OPIK_URL_OVERRIDE;
+      currentProjectName = opikCfg.projectName ?? trimOrUndefined(process.env.OPIK_PROJECT_NAME) ?? "openclaw";
+      currentWorkspaceName =
+        opikCfg.workspaceName ?? trimOrUndefined(process.env.OPIK_WORKSPACE) ?? "default";
+      currentTags = opikCfg.tags ?? ["openclaw"];
+      toolResultPersistSanitizeEnabled = opikCfg.toolResultPersistSanitizeEnabled === true;
+
+      if (!currentEnabled) {
         return;
       }
 
-      const apiKey = opikCfg.apiKey ?? process.env.OPIK_API_KEY;
-      const apiUrl = opikCfg.apiUrl ?? process.env.OPIK_URL_OVERRIDE;
-      const projectName = opikCfg.projectName ?? trimOrUndefined(process.env.OPIK_PROJECT_NAME) ?? "openclaw";
-      const workspaceName =
-        opikCfg.workspaceName ?? trimOrUndefined(process.env.OPIK_WORKSPACE) ?? "default";
-      const tags = opikCfg.tags ?? ["openclaw"];
-      attachmentBaseUrl = (apiUrl ?? DEFAULT_ATTACHMENT_BASE_URL).replace(/\/+$/, "");
+      registerPluginHooks();
+
+      attachmentBaseUrl = (currentApiUrl ?? DEFAULT_ATTACHMENT_BASE_URL).replace(/\/+$/, "");
 
       staleTraceCleanupEnabled = opikCfg.staleTraceCleanupEnabled !== false;
       staleTraceTimeoutMs = Math.max(
@@ -466,147 +629,17 @@ export function createOpikService(
       flushRetryBaseDelayMs = asNonNegativeNumber(opikCfg.flushRetryBaseDelayMs) ??
         DEFAULT_FLUSH_RETRY_BASE_DELAY_MS;
 
-      client = new Opik({
-        apiKey,
-        ...(apiUrl ? { apiUrl } : {}),
-        projectName,
-        workspaceName,
-      });
-
-      await validateProjectTarget({
-        client,
-        projectName,
-        workspaceName,
-      });
-
-      registerLlmHooks({
-        api,
-        getClient: () => client,
-        activeTraces,
-        tags,
-        projectName,
-        rememberSessionCorrelation,
-        closeActiveTrace,
-        forgetSessionCorrelation,
-        applyContextMeta,
-        safeSpanUpdate,
-        safeSpanEnd,
-        scheduleMediaAttachmentUploads: attachmentUploader.scheduleMediaAttachmentUploads,
-        warn: (message) => log.warn(message),
-        formatError,
-      });
-
-      registerToolHooks({
-        api,
-        getClient: () => client,
-        activeTraces,
-        sessionByAgentId,
-        getLastActiveSessionKey: () => lastActiveSessionKey,
-        rememberSessionCorrelation,
-        resolveSessionSpanContainer,
-        warnMissingAfterToolSessionKey,
-        nextSpanSeq: () => ++spanSeq,
-        safeSpanUpdate,
-        safeSpanEnd,
-        scheduleMediaAttachmentUploads: attachmentUploader.scheduleMediaAttachmentUploads,
-        projectName,
-        warn: (message) => log.warn(message),
-        formatError,
-      });
-
-      registerSubagentHooks({
-        api,
-        getClient: () => client,
-        rememberSessionCorrelation,
-        resolveSubagentSpanContainer,
-        getSubagentSpanHost,
-        rememberSubagentSpanHost,
-        forgetSubagentSpanHost,
-        safeSpanUpdate,
-        safeSpanEnd,
-        warn: (message) => log.warn(message),
-        formatError,
-      });
-
-      // =====================================================================
-      // Hook: tool_result_persist — sanitize persisted tool messages (opt-in)
-      // =====================================================================
-      if (opikCfg.toolResultPersistSanitizeEnabled === true) {
-        api.on("tool_result_persist", (event) => {
-          try {
-            const eventObj = event as Record<string, unknown>;
-            const message = eventObj.message;
-            if (!message || typeof message !== "object") return;
-
-            const sanitizedMessage = sanitizeValueForOpik(message);
-            if (sanitizedMessage !== message) {
-              return { message: sanitizedMessage };
-            }
-          } catch (err) {
-            log.warn(`opik: tool_result_persist failed: ${formatError(err)}`);
-          }
-        });
+      const readyClient = ensureClient();
+      if (!readyClient) {
+        return;
       }
 
-      // =====================================================================
-      // Hook: agent_end — Finalize Trace
-      // =====================================================================
-      api.on("agent_end", (event, agentCtx) => {
-        const sessionKey = agentCtx.sessionKey;
-        if (!sessionKey) return;
-        rememberSessionCorrelation(sessionKey, agentCtx.agentId);
-
-        const active = activeTraces.get(sessionKey);
-        if (!active) return;
-
-        applyContextMeta(active, agentCtx as Record<string, unknown>);
-        // Close any orphaned tool/subagent spans synchronously.
-        for (const [toolKey, toolSpan] of active.toolSpans) {
-          safeSpanEnd(toolSpan, `agent_end orphan tool sessionKey=${sessionKey} toolKey=${toolKey}`);
-        }
-        active.toolSpans.clear();
-
-        for (const [subagentKey, subagentSpan] of active.subagentSpans) {
-          safeSpanEnd(
-            subagentSpan,
-            `agent_end orphan subagent sessionKey=${sessionKey} subagentKey=${subagentKey}`,
-          );
-        }
-        active.subagentSpans.clear();
-
-        // Store agent-end data for deferred finalization.
-        active.agentEnd = {
-          success: event.success,
-          error: typeof event.error === "string" ? sanitizeStringForOpik(event.error) : event.error,
-          durationMs: event.durationMs,
-          messages: (sanitizeValueForOpik(
-            ((event as Record<string, unknown>).messages as unknown[]) ?? [],
-          ) as unknown[]) ?? [],
-        };
-
-        attachmentUploader.scheduleMediaAttachmentUploads({
-          entityType: "trace",
-          entity: active.trace,
-          projectName,
-          reason: `agent_end sessionKey=${sessionKey}`,
-          payloads: [
-            event.error,
-            ((event as Record<string, unknown>).messages as unknown[] | undefined)?.at(-1),
-          ],
-        });
-
-        // Defer finalization to a microtask so llm_output (which fires on the
-        // same synchronous call stack) can store output/usage first.
-        const traceRef = active.trace;
-        queueMicrotask(() => {
-          const current = activeTraces.get(sessionKey);
-          if (current && current.trace === traceRef) finalizeTrace(sessionKey);
-        });
+      await validateProjectTarget({
+        client: readyClient,
+        projectName: currentProjectName,
+        workspaceName: currentWorkspaceName,
       });
 
-      // =====================================================================
-      // Diagnostic event: model.usage — Accumulate cost/context info
-      // =====================================================================
       const unsubscribeDiagnostics = onDiagnosticEvent((evt: DiagnosticEventPayload) => {
         if (evt.type !== "model.usage") return;
 
@@ -687,7 +720,7 @@ export function createOpikService(
       };
 
       log.info(
-        `opik: exporting traces to project "${projectName}" (staleCleanup=${staleTraceCleanupEnabled ? "on" : "off"}, staleTimeoutMs=${staleTraceTimeoutMs}, staleSweepMs=${staleSweepIntervalMs}, flushRetryCount=${flushRetryCount}, flushRetryBaseDelayMs=${flushRetryBaseDelayMs})`,
+        `opik: exporting traces to project "${currentProjectName}" (staleCleanup=${staleTraceCleanupEnabled ? "on" : "off"}, staleTimeoutMs=${staleTraceTimeoutMs}, staleSweepMs=${staleSweepIntervalMs}, flushRetryCount=${flushRetryCount}, flushRetryBaseDelayMs=${flushRetryBaseDelayMs})`,
       );
     },
 

--- a/src/service/hooks/llm.ts
+++ b/src/service/hooks/llm.ts
@@ -14,8 +14,8 @@ type LlmHooksDeps = {
   api: OpenClawPluginApi;
   getClient: () => Opik | null;
   activeTraces: Map<string, ActiveTrace>;
-  tags: string[];
-  projectName: string;
+  getTags: () => string[];
+  getProjectName: () => string;
   rememberSessionCorrelation: (sessionKey: string, agentId?: unknown) => void;
   closeActiveTrace: (active: ActiveTrace, reason: string) => void;
   forgetSessionCorrelation: (sessionKey: string) => void;
@@ -73,7 +73,7 @@ export function registerLlmHooks(deps: LlmHooksDeps): void {
           ...(channelId ? { channel: channelId, channelId } : {}),
           ...(trigger ? { trigger } : {}),
         },
-        tags: deps.tags.length > 0 ? deps.tags : undefined,
+        tags: deps.getTags().length > 0 ? deps.getTags() : undefined,
       });
     } catch (err) {
       deps.warn(`opik: trace creation failed (sessionKey=${sessionKey}): ${deps.formatError(err)}`);
@@ -118,7 +118,7 @@ export function registerLlmHooks(deps: LlmHooksDeps): void {
     deps.scheduleMediaAttachmentUploads({
       entityType: "trace",
       entity: trace,
-      projectName: deps.projectName,
+      projectName: deps.getProjectName(),
       reason: `llm_input sessionKey=${sessionKey}`,
       payloads: [event.prompt, Array.isArray(event.historyMessages) ? event.historyMessages.at(-1) : undefined],
     });

--- a/src/service/hooks/tool.ts
+++ b/src/service/hooks/tool.ts
@@ -25,7 +25,7 @@ type ToolHooksDeps = {
     reason: string;
     payloads: unknown[];
   }) => void;
-  projectName: string;
+  getProjectName: () => string;
   warn: (message: string) => void;
   formatError: (err: unknown) => string;
 };
@@ -89,7 +89,7 @@ export function registerToolHooks(deps: ToolHooksDeps): void {
     deps.scheduleMediaAttachmentUploads({
       entityType: "span",
       entity: toolSpan,
-      projectName: deps.projectName,
+      projectName: deps.getProjectName(),
       reason: `before_tool_call sessionKey=${sessionKey} tool=${event.toolName}`,
       payloads: [event.params],
     });
@@ -199,7 +199,7 @@ export function registerToolHooks(deps: ToolHooksDeps): void {
     deps.scheduleMediaAttachmentUploads({
       entityType: "span",
       entity: matchedSpan,
-      projectName: deps.projectName,
+      projectName: deps.getProjectName(),
       reason: `after_tool_call sessionKey=${sessionKey} tool=${event.toolName}`,
       payloads: [event.params, event.result, event.error],
     });


### PR DESCRIPTION
## Summary
- register tracing hooks during plugin registration so OpenClaw runtime hook contexts can observe `llm_input`, `llm_output`, tool, subagent, and `agent_end` events before `service.start()` runs
- lazily initialize the Opik client and defer tag/project-name lookups so early-registered hooks still use the runtime-resolved config
- keep `tool_result_persist` registered but make it a no-op when sanitization is disabled, and add regression coverage for the immediate-registration path

## Root cause
In recent OpenClaw runtimes, lifecycle hooks can fire in a context where `service.start()` has not initialized the Opik client. Because this plugin only registered hooks from `start()`, normal traces were never created in that hook context and only later diagnostic fallbacks reached Opik.

## Verification
- `npm test`
- `npm run typecheck`
- live OpenClaw check: a direct `openclaw agent` run now emits a normal `gpt-5.3-codex · webchat` trace again
- live PinchBench check: `task_00_sanity` now records a normal `gpt-5.3-codex · webchat` trace for `agent:bench-default-gpt-5-3-codex:main` in Opik instead of only fallback diagnostics
