### PR TITLE
fix: register hooks at createOpikService() time to prevent zero traces

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -427,6 +427,118 @@ export function createOpikService(
     scheduleFlush(`trace-finalized sessionKey=${sessionKey}`);
   }
 
+  // ==========================================================================
+  // Register all hooks at createOpikService() time (i.e. during register()),
+  // NOT inside start(). The OpenClaw gateway initialises its global hook runner
+  // once, immediately after register() returns. Any api.on() calls made inside
+  // start() execute after the runner is sealed and are silently ignored —
+  // meaning the plugin captures zero traces with the original code.
+  //
+  // All hooks guard with `if (!client) return` so they are safe to call in the
+  // brief window between register() and the first start() invocation.
+  // ==========================================================================
+  registerLlmHooks({
+    api,
+    getClient: () => client,
+    activeTraces,
+    tags: pluginConfig.tags ?? ["openclaw"],
+    projectName: pluginConfig.projectName ?? "openclaw",
+    rememberSessionCorrelation,
+    closeActiveTrace,
+    forgetSessionCorrelation,
+    applyContextMeta,
+    safeSpanUpdate,
+    safeSpanEnd,
+    scheduleMediaAttachmentUploads: attachmentUploader.scheduleMediaAttachmentUploads,
+    warn: (message) => log.warn(message),
+    formatError,
+  });
+
+  registerToolHooks({
+    api,
+    getClient: () => client,
+    activeTraces,
+    sessionByAgentId,
+    getLastActiveSessionKey: () => lastActiveSessionKey,
+    rememberSessionCorrelation,
+    resolveSessionSpanContainer,
+    warnMissingAfterToolSessionKey,
+    nextSpanSeq: () => ++spanSeq,
+    safeSpanUpdate,
+    safeSpanEnd,
+    scheduleMediaAttachmentUploads: attachmentUploader.scheduleMediaAttachmentUploads,
+    projectName: pluginConfig.projectName ?? "openclaw",
+    warn: (message) => log.warn(message),
+    formatError,
+  });
+
+  registerSubagentHooks({
+    api,
+    getClient: () => client,
+    rememberSessionCorrelation,
+    resolveSubagentSpanContainer,
+    getSubagentSpanHost,
+    rememberSubagentSpanHost,
+    forgetSubagentSpanHost,
+    safeSpanUpdate,
+    safeSpanEnd,
+    warn: (message) => log.warn(message),
+    formatError,
+  });
+
+  api.on("tool_result_persist", (event) => {
+    if (!client) return;
+    if (pluginConfig.toolResultPersistSanitizeEnabled !== true) return;
+    try {
+      const eventObj = event as Record<string, unknown>;
+      const message = eventObj.message;
+      if (!message || typeof message !== "object") return;
+      const sanitizedMessage = sanitizeValueForOpik(message);
+      if (sanitizedMessage !== message) return { message: sanitizedMessage };
+    } catch (err) {
+      log.warn(`opik: tool_result_persist failed: ${formatError(err)}`);
+    }
+  });
+
+  api.on("agent_end", (event, agentCtx) => {
+    if (!client) return;
+    const sessionKey = agentCtx.sessionKey;
+    if (!sessionKey) return;
+    rememberSessionCorrelation(sessionKey, agentCtx.agentId);
+    const active = activeTraces.get(sessionKey);
+    if (!active) return;
+    applyContextMeta(active, agentCtx as Record<string, unknown>);
+    for (const [toolKey, toolSpan] of active.toolSpans)
+      safeSpanEnd(toolSpan, `agent_end orphan tool sessionKey=${sessionKey} toolKey=${toolKey}`);
+    active.toolSpans.clear();
+    for (const [subagentKey, subagentSpan] of active.subagentSpans)
+      safeSpanEnd(subagentSpan, `agent_end orphan subagent sessionKey=${sessionKey} subagentKey=${subagentKey}`);
+    active.subagentSpans.clear();
+    active.agentEnd = {
+      success: event.success,
+      error: typeof event.error === "string" ? sanitizeStringForOpik(event.error) : event.error,
+      durationMs: event.durationMs,
+      messages: (sanitizeValueForOpik(
+        ((event as Record<string, unknown>).messages as unknown[]) ?? [],
+      ) as unknown[]) ?? [],
+    };
+    attachmentUploader.scheduleMediaAttachmentUploads({
+      entityType: "trace",
+      entity: active.trace,
+      projectName: pluginConfig.projectName ?? "openclaw",
+      reason: `agent_end sessionKey=${sessionKey}`,
+      payloads: [
+        event.error,
+        ((event as Record<string, unknown>).messages as unknown[] | undefined)?.at(-1),
+      ],
+    });
+    const traceRef = active.trace;
+    queueMicrotask(() => {
+      const current = activeTraces.get(sessionKey);
+      if (current && current.trace === traceRef) finalizeTrace(sessionKey);
+    });
+  });
+
   return {
     id: OPIK_PLUGIN_ID,
     async start(ctx) {
@@ -479,130 +591,8 @@ export function createOpikService(
         workspaceName,
       });
 
-      registerLlmHooks({
-        api,
-        getClient: () => client,
-        activeTraces,
-        tags,
-        projectName,
-        rememberSessionCorrelation,
-        closeActiveTrace,
-        forgetSessionCorrelation,
-        applyContextMeta,
-        safeSpanUpdate,
-        safeSpanEnd,
-        scheduleMediaAttachmentUploads: attachmentUploader.scheduleMediaAttachmentUploads,
-        warn: (message) => log.warn(message),
-        formatError,
-      });
-
-      registerToolHooks({
-        api,
-        getClient: () => client,
-        activeTraces,
-        sessionByAgentId,
-        getLastActiveSessionKey: () => lastActiveSessionKey,
-        rememberSessionCorrelation,
-        resolveSessionSpanContainer,
-        warnMissingAfterToolSessionKey,
-        nextSpanSeq: () => ++spanSeq,
-        safeSpanUpdate,
-        safeSpanEnd,
-        scheduleMediaAttachmentUploads: attachmentUploader.scheduleMediaAttachmentUploads,
-        projectName,
-        warn: (message) => log.warn(message),
-        formatError,
-      });
-
-      registerSubagentHooks({
-        api,
-        getClient: () => client,
-        rememberSessionCorrelation,
-        resolveSubagentSpanContainer,
-        getSubagentSpanHost,
-        rememberSubagentSpanHost,
-        forgetSubagentSpanHost,
-        safeSpanUpdate,
-        safeSpanEnd,
-        warn: (message) => log.warn(message),
-        formatError,
-      });
-
-      // =====================================================================
-      // Hook: tool_result_persist — sanitize persisted tool messages (opt-in)
-      // =====================================================================
-      if (opikCfg.toolResultPersistSanitizeEnabled === true) {
-        api.on("tool_result_persist", (event) => {
-          try {
-            const eventObj = event as Record<string, unknown>;
-            const message = eventObj.message;
-            if (!message || typeof message !== "object") return;
-
-            const sanitizedMessage = sanitizeValueForOpik(message);
-            if (sanitizedMessage !== message) {
-              return { message: sanitizedMessage };
-            }
-          } catch (err) {
-            log.warn(`opik: tool_result_persist failed: ${formatError(err)}`);
-          }
-        });
-      }
-
-      // =====================================================================
-      // Hook: agent_end — Finalize Trace
-      // =====================================================================
-      api.on("agent_end", (event, agentCtx) => {
-        const sessionKey = agentCtx.sessionKey;
-        if (!sessionKey) return;
-        rememberSessionCorrelation(sessionKey, agentCtx.agentId);
-
-        const active = activeTraces.get(sessionKey);
-        if (!active) return;
-
-        applyContextMeta(active, agentCtx as Record<string, unknown>);
-        // Close any orphaned tool/subagent spans synchronously.
-        for (const [toolKey, toolSpan] of active.toolSpans) {
-          safeSpanEnd(toolSpan, `agent_end orphan tool sessionKey=${sessionKey} toolKey=${toolKey}`);
-        }
-        active.toolSpans.clear();
-
-        for (const [subagentKey, subagentSpan] of active.subagentSpans) {
-          safeSpanEnd(
-            subagentSpan,
-            `agent_end orphan subagent sessionKey=${sessionKey} subagentKey=${subagentKey}`,
-          );
-        }
-        active.subagentSpans.clear();
-
-        // Store agent-end data for deferred finalization.
-        active.agentEnd = {
-          success: event.success,
-          error: typeof event.error === "string" ? sanitizeStringForOpik(event.error) : event.error,
-          durationMs: event.durationMs,
-          messages: (sanitizeValueForOpik(
-            ((event as Record<string, unknown>).messages as unknown[]) ?? [],
-          ) as unknown[]) ?? [],
-        };
-
-        attachmentUploader.scheduleMediaAttachmentUploads({
-          entityType: "trace",
-          entity: active.trace,
-          projectName,
-          reason: `agent_end sessionKey=${sessionKey}`,
-          payloads: [
-            event.error,
-            ((event as Record<string, unknown>).messages as unknown[] | undefined)?.at(-1),
-          ],
-        });
-
-        // Defer finalization to a microtask so llm_output (which fires on the
-        // same synchronous call stack) can store output/usage first.
-        const traceRef = active.trace;
-        queueMicrotask(() => {
-          const current = activeTraces.get(sessionKey);
-          if (current && current.trace === traceRef) finalizeTrace(sessionKey);
-        });
-      });
+      // Hooks are registered at createOpikService() time (see below) so they
+      // are captured by the gateway hook runner before start() is called.
 
       // =====================================================================
       // Diagnostic event: model.usage — Accumulate cost/context info

--- a/src/service/hooks/llm.ts
+++ b/src/service/hooks/llm.ts
@@ -61,6 +61,7 @@ export function registerLlmHooks(deps: LlmHooksDeps): void {
       }) as Record<string, unknown>;
       trace = client.trace({
         name: `${event.model} · ${channelId ?? "unknown"}`,
+        projectName: deps.projectName,
         threadId: sessionKey,
         input: sanitizedTraceInput,
         metadata: {


### PR DESCRIPTION
The OpenClaw gateway initializes its global hook runner once, right after register() returns. Any api.on() calls inside start() run after the runner is sealed and are silently ignored, so the plugin captures zero traces for every user.

Fix: move all hook registrations (registerLlmHooks, registerToolHooks, registerSubagentHooks, tool_result_persist, agent_end) into the body of createOpikService() before the return statement. This way they run during register() and get picked up by the hook runner.

Also adds projectName to client.trace() so traces route to the configured project rather than silently defaulting to "Default Project". 

Confirmed working on OpenClaw 2026.4.8, plugin v0.2.9.

Fixes #48,  #49 and  #61

Additionally, #36 was closed back in March with PR #43. That fix added a 
warning for invalid project names. The hook timing issue was still there 
and this is what was actually causing it

