### PR TITLE
ci: E2E integration test against latest OpenClaw

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -77,25 +77,21 @@ jobs:
             "gateway": {
               "mode": "local",
               "bind": "loopback",
-              "auth": "none",
+              "auth": { "mode": "none" },
               "port": 18789
             },
             "models": {
               "providers": {
                 "openai": {
-                  "apiUrl": "http://127.0.0.1:18790/v1",
-                  "apiKey": "mock-key"
+                  "baseUrl": "http://127.0.0.1:18790/v1",
+                  "apiKey": "mock-key",
+                  "models": ["gpt-4o-mini"]
                 }
-              },
-              "defaults": {
-                "provider": "openai",
-                "model": "gpt-4o-mini"
               }
             },
             "agents": {
               "defaults": {
-                "model": "gpt-4o-mini",
-                "provider": "openai"
+                "model": "gpt-4o-mini"
               }
             },
             "plugins": {

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,6 +28,8 @@ on:
       - "src/**"
       - "scripts/**"
       - "package.json"
+  schedule:
+    - cron: '0 6 * * *'  # daily at 6am UTC — catches new OpenClaw releases breaking the plugin
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,6 +44,11 @@ jobs:
         openclaw-version:
           - latest
 
+    env:
+      OPENCLAW_GATEWAY_TOKEN: e2e-test-token
+      OPENAI_API_KEY: mock-key
+      OPENAI_BASE_URL: http://127.0.0.1:18790/v1
+
     steps:
       - name: Checkout plugin source
         uses: actions/checkout@v5
@@ -161,9 +166,6 @@ jobs:
 
       - name: Start OpenClaw gateway
         run: openclaw gateway run &
-        env:
-          OPENAI_API_KEY: mock-key
-          OPENAI_BASE_URL: http://127.0.0.1:18790/v1
 
       - name: Wait for gateway to be ready
         run: |
@@ -176,8 +178,6 @@ jobs:
       - name: Run agent turn
         run: openclaw agent --agent main --message "ping" --deliver
         timeout-minutes: 2
-        env:
-          OPENCLAW_GATEWAY_TOKEN: e2e-test-token
 
       - name: Stop gateway and flush traces
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -150,7 +150,7 @@ jobs:
           openclaw health
 
       - name: Run agent turn
-        run: openclaw agent --message "ping" --deliver
+        run: openclaw agent --agent main --message "ping" --deliver
         timeout-minutes: 2
 
       - name: Stop gateway and flush traces

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,7 +55,7 @@ jobs:
           cache: "npm"
 
       - name: Setup npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.6.2
 
       - name: Install OpenClaw (${{ matrix.openclaw-version }})
         run: npm install -g openclaw@${{ matrix.openclaw-version }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,6 +45,8 @@ jobs:
           - latest
 
     env:
+      E2E_RESULT_FILE: e2e-result.json
+      E2E_LLM_RESULT_FILE: e2e-llm-result.json
       OPENCLAW_GATEWAY_TOKEN: e2e-test-token
       OPENAI_API_KEY: mock-key
       OPENAI_BASE_URL: http://127.0.0.1:18790/v1
@@ -146,13 +148,16 @@ jobs:
         run: openclaw plugins install ./opik-opik-openclaw-*.tgz
 
       - name: Start mock Opik server
-        run: node scripts/mock-opik-server.mjs &
+        run: |
+          node scripts/mock-opik-server.mjs > mock-opik.log 2>&1 &
+          echo $! > mock-opik.pid
         env:
           MOCK_OPIK_PORT: "18791"
-          E2E_RESULT_FILE: e2e-result.json
 
       - name: Start mock LLM server
-        run: node scripts/mock-llm-server.mjs &
+        run: |
+          node scripts/mock-llm-server.mjs > mock-llm.log 2>&1 &
+          echo $! > mock-llm.pid
         env:
           MOCK_LLM_PORT: "18790"
 
@@ -165,7 +170,9 @@ jobs:
           done
 
       - name: Start OpenClaw gateway
-        run: openclaw gateway run &
+        run: |
+          openclaw gateway run > gateway.log 2>&1 &
+          echo $! > gateway.pid
 
       - name: Wait for gateway to be ready
         run: |
@@ -176,29 +183,46 @@ jobs:
           openclaw health
 
       - name: Run agent turn
-        run: openclaw agent --agent main --message "ping" --deliver
+        run: |
+          set -o pipefail
+          openclaw agent --agent main --message "ping" --deliver 2>&1 | tee agent-output.log
+          if grep -q "falling back to embedded" agent-output.log; then
+            echo "[e2e] FAIL: gateway turn fell back to embedded mode"
+            exit 1
+          fi
         timeout-minutes: 2
 
       - name: Stop gateway and flush traces
         run: |
           openclaw gateway stop || true
+          if [ -f gateway.pid ]; then
+            kill "$(cat gateway.pid)" > /dev/null 2>&1 || true
+          fi
           sleep 2
 
       - name: Stop mock servers and collect results
         run: |
-          pkill -f mock-opik-server.mjs || true
-          pkill -f mock-llm-server.mjs || true
+          if [ -f mock-opik.pid ]; then
+            kill "$(cat mock-opik.pid)" > /dev/null 2>&1 || true
+          fi
+          if [ -f mock-llm.pid ]; then
+            kill "$(cat mock-llm.pid)" > /dev/null 2>&1 || true
+          fi
           sleep 1
 
-      - name: Assert traces and spans were exported
+      - name: Assert E2E results
         run: node scripts/check-e2e-result.mjs
-        env:
-          E2E_RESULT_FILE: e2e-result.json
 
       - name: Upload E2E result on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-result
-          path: e2e-result.json
+          name: e2e-debug
+          path: |
+            e2e-result.json
+            e2e-llm-result.json
+            agent-output.log
+            gateway.log
+            mock-opik.log
+            mock-llm.log
           if-no-files-found: ignore

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -80,18 +80,21 @@ jobs:
               "auth": { "mode": "none" },
               "port": 18789
             },
-            "models": {
-              "providers": {
-                "openai": {
-                  "baseUrl": "http://127.0.0.1:18790/v1",
-                  "apiKey": "mock-key",
-                  "models": [{ "name": "gpt-4o-mini" }]
+            "agents": {
+              "defaults": {
+                "model": {
+                  "primary": "openai/gpt-4o-mini"
                 }
               }
             },
-            "agents": {
-              "defaults": {
-                "model": "gpt-4o-mini"
+            "auth": {
+              "profiles": {
+                "openai:default": {
+                  "provider": "openai",
+                  "mode": "api_key",
+                  "apiUrl": "http://127.0.0.1:18790/v1",
+                  "apiKey": "mock-key"
+                }
               }
             },
             "plugins": {

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,8 +48,6 @@ jobs:
       E2E_RESULT_FILE: e2e-result.json
       E2E_LLM_RESULT_FILE: e2e-llm-result.json
       OPENCLAW_GATEWAY_TOKEN: e2e-test-token
-      OPENAI_API_KEY: mock-key
-      OPENAI_BASE_URL: http://127.0.0.1:18790/v1
 
     steps:
       - name: Checkout plugin source
@@ -101,15 +99,34 @@ jobs:
             "agents": {
               "defaults": {
                 "model": {
-                  "primary": "openai/gpt-4o-mini"
+                  "primary": "mock-openai/gpt-4o-mini"
                 }
               }
             },
-            "auth": {
-              "profiles": {
-                "openai:default": {
-                  "provider": "openai",
-                  "mode": "api_key"
+            "models": {
+              "mode": "merge",
+              "providers": {
+                "mock-openai": {
+                  "baseUrl": "http://127.0.0.1:18790/v1",
+                  "apiKey": "mock-key",
+                  "authHeader": true,
+                  "api": "openai-responses",
+                  "models": [
+                    {
+                      "id": "gpt-4o-mini",
+                      "name": "Mock GPT-4o Mini",
+                      "reasoning": false,
+                      "input": ["text"],
+                      "cost": {
+                        "input": 0,
+                        "output": 0,
+                        "cacheRead": 0,
+                        "cacheWrite": 0
+                      },
+                      "contextWindow": 128000,
+                      "maxTokens": 16384
+                    }
+                  ]
                 }
               }
             },
@@ -127,19 +144,6 @@ jobs:
                   }
                 }
               }
-            }
-          }
-          EOF
-
-      - name: Write agent auth credentials
-        run: |
-          mkdir -p ~/.openclaw/agents/main/agent
-          cat > ~/.openclaw/agents/main/agent/auth-profiles.json << 'EOF'
-          {
-            "openai:default": {
-              "provider": "openai",
-              "mode": "api_key",
-              "apiKey": "mock-key"
             }
           }
           EOF

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -85,7 +85,7 @@ jobs:
                 "openai": {
                   "baseUrl": "http://127.0.0.1:18790/v1",
                   "apiKey": "mock-key",
-                  "models": [{ "id": "gpt-4o-mini" }]
+                  "models": [{ "name": "gpt-4o-mini" }]
                 }
               }
             },

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,176 @@
+name: E2E Integration
+
+# Validates that the plugin works end-to-end against the latest published
+# OpenClaw release. Installs OpenClaw fresh, builds and installs the plugin
+# from source, starts the gateway with a mock LLM + mock Opik server, runs
+# a real agent turn, and asserts that traces and spans were exported.
+#
+# This catches regressions caused by OpenClaw plugin lifecycle changes that
+# unit tests cannot detect.
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/e2e.yml"
+      - "index.ts"
+      - "src/**"
+      - "scripts/**"
+      - "package.json"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/e2e.yml"
+      - "index.ts"
+      - "src/**"
+      - "scripts/**"
+      - "package.json"
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    name: E2E against OpenClaw ${{ matrix.openclaw-version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    strategy:
+      fail-fast: false
+      matrix:
+        openclaw-version:
+          - latest
+
+    steps:
+      - name: Checkout plugin source
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22.12.0"
+          cache: "npm"
+
+      - name: Setup npm
+        run: npm install -g npm@11.6.2
+
+      - name: Install OpenClaw (${{ matrix.openclaw-version }})
+        run: npm install -g openclaw@${{ matrix.openclaw-version }}
+
+      - name: Print OpenClaw version
+        run: openclaw --version
+
+      - name: Install plugin dependencies
+        run: npm ci
+
+      - name: Build plugin tarball
+        run: npm pack
+
+      - name: Write OpenClaw config
+        run: |
+          mkdir -p ~/.openclaw/agents/main/sessions
+          cat > ~/.openclaw/openclaw.json << 'EOF'
+          {
+            "gateway": {
+              "mode": "local",
+              "bind": "loopback",
+              "auth": "none",
+              "port": 18789
+            },
+            "models": {
+              "providers": {
+                "openai": {
+                  "apiUrl": "http://127.0.0.1:18790/v1",
+                  "apiKey": "mock-key"
+                }
+              },
+              "defaults": {
+                "provider": "openai",
+                "model": "gpt-4o-mini"
+              }
+            },
+            "agents": {
+              "defaults": {
+                "model": "gpt-4o-mini",
+                "provider": "openai"
+              }
+            },
+            "plugins": {
+              "allow": ["opik-openclaw"],
+              "entries": {
+                "opik-openclaw": {
+                  "enabled": true,
+                  "config": {
+                    "enabled": true,
+                    "apiUrl": "http://127.0.0.1:18791",
+                    "apiKey": "mock-key",
+                    "projectName": "e2e-test",
+                    "workspaceName": "default"
+                  }
+                }
+              }
+            }
+          }
+          EOF
+
+      - name: Install plugin from tarball
+        run: openclaw plugins install ./opik-opik-openclaw-*.tgz
+
+      - name: Start mock Opik server
+        run: node scripts/mock-opik-server.mjs &
+        env:
+          MOCK_OPIK_PORT: "18791"
+          E2E_RESULT_FILE: e2e-result.json
+
+      - name: Start mock LLM server
+        run: node scripts/mock-llm-server.mjs &
+        env:
+          MOCK_LLM_PORT: "18790"
+
+      - name: Wait for mock servers to be ready
+        run: |
+          for i in $(seq 1 10); do
+            curl -sf http://127.0.0.1:18791/health > /dev/null 2>&1 && \
+            curl -sf http://127.0.0.1:18790/v1/models > /dev/null 2>&1 && break
+            sleep 1
+          done
+
+      - name: Start OpenClaw gateway
+        run: openclaw gateway run &
+
+      - name: Wait for gateway to be ready
+        run: |
+          for i in $(seq 1 15); do
+            openclaw health > /dev/null 2>&1 && break
+            sleep 1
+          done
+          openclaw health
+
+      - name: Run agent turn
+        run: openclaw agent --message "ping" --deliver
+        timeout-minutes: 2
+
+      - name: Stop gateway and flush traces
+        run: |
+          openclaw gateway stop || true
+          sleep 2
+
+      - name: Stop mock servers and collect results
+        run: |
+          pkill -f mock-opik-server.mjs || true
+          pkill -f mock-llm-server.mjs || true
+          sleep 1
+
+      - name: Assert traces and spans were exported
+        run: node scripts/check-e2e-result.mjs
+        env:
+          E2E_RESULT_FILE: e2e-result.json
+
+      - name: Upload E2E result on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-result
+          path: e2e-result.json
+          if-no-files-found: ignore

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -91,9 +91,7 @@ jobs:
               "profiles": {
                 "openai:default": {
                   "provider": "openai",
-                  "mode": "api_key",
-                  "apiUrl": "http://127.0.0.1:18790/v1",
-                  "apiKey": "mock-key"
+                  "mode": "api_key"
                 }
               }
             },
@@ -139,6 +137,9 @@ jobs:
 
       - name: Start OpenClaw gateway
         run: openclaw gateway run &
+        env:
+          OPENAI_API_KEY: mock-key
+          OPENAI_BASE_URL: http://127.0.0.1:18790/v1
 
       - name: Wait for gateway to be ready
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -85,7 +85,7 @@ jobs:
                 "openai": {
                   "baseUrl": "http://127.0.0.1:18790/v1",
                   "apiKey": "mock-key",
-                  "models": ["gpt-4o-mini"]
+                  "models": [{ "id": "gpt-4o-mini" }]
                 }
               }
             },

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,6 +57,17 @@ jobs:
       - name: Setup npm
         run: npm install -g npm@11.6.2
 
+      - name: Setup npm global prefix for caching
+        run: |
+          npm config set prefix ~/.npm-global
+          echo "$HOME/.npm-global/bin" >> $GITHUB_PATH
+
+      - name: Cache OpenClaw install
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm-global
+          key: openclaw-${{ matrix.openclaw-version }}-${{ runner.os }}-${{ runner.arch }}
+
       - name: Install OpenClaw (${{ matrix.openclaw-version }})
         run: npm install -g openclaw@${{ matrix.openclaw-version }}
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -77,7 +77,7 @@ jobs:
             "gateway": {
               "mode": "local",
               "bind": "loopback",
-              "auth": { "mode": "none" },
+              "auth": { "mode": "token", "token": "e2e-test-token" },
               "port": 18789
             },
             "agents": {
@@ -109,6 +109,19 @@ jobs:
                   }
                 }
               }
+            }
+          }
+          EOF
+
+      - name: Write agent auth credentials
+        run: |
+          mkdir -p ~/.openclaw/agents/main/agent
+          cat > ~/.openclaw/agents/main/agent/auth-profiles.json << 'EOF'
+          {
+            "openai:default": {
+              "provider": "openai",
+              "mode": "api_key",
+              "apiKey": "mock-key"
             }
           }
           EOF
@@ -152,6 +165,8 @@ jobs:
       - name: Run agent turn
         run: openclaw agent --agent main --message "ping" --deliver
         timeout-minutes: 2
+        env:
+          OPENCLAW_GATEWAY_TOKEN: e2e-test-token
 
       - name: Stop gateway and flush traces
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,11 +51,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: "22.12.0"
+          node-version: "22.x"
           cache: "npm"
 
       - name: Setup npm
-        run: npm install -g npm@11.6.2
+        run: npm install -g npm@latest
 
       - name: Install OpenClaw (${{ matrix.openclaw-version }})
         run: npm install -g openclaw@${{ matrix.openclaw-version }}

--- a/scripts/check-e2e-result.mjs
+++ b/scripts/check-e2e-result.mjs
@@ -7,6 +7,7 @@
 import fs from "node:fs";
 
 const RESULT_FILE = process.env.E2E_RESULT_FILE ?? "e2e-result.json";
+const LLM_RESULT_FILE = process.env.E2E_LLM_RESULT_FILE ?? "e2e-llm-result.json";
 
 if (!fs.existsSync(RESULT_FILE)) {
   console.error(`[check-e2e] FAIL: result file not found: ${RESULT_FILE}`);
@@ -16,6 +17,15 @@ if (!fs.existsSync(RESULT_FILE)) {
 
 const result = JSON.parse(fs.readFileSync(RESULT_FILE, "utf8"));
 console.log("[check-e2e] result:", result);
+
+if (!fs.existsSync(LLM_RESULT_FILE)) {
+  console.error(`[check-e2e] FAIL: LLM result file not found: ${LLM_RESULT_FILE}`);
+  console.error("  The mock LLM server may not have written its result (SIGTERM not received?).");
+  process.exit(1);
+}
+
+const llmResult = JSON.parse(fs.readFileSync(LLM_RESULT_FILE, "utf8"));
+console.log("[check-e2e] llm result:", llmResult);
 
 const failures = [];
 
@@ -27,8 +37,22 @@ if (result.spans < 1) {
   failures.push(`Expected ≥1 span batch, got ${result.spans}`);
 }
 
+if (result.tracePatches < 1) {
+  failures.push(`Expected ≥1 trace patch, got ${result.tracePatches}`);
+}
+
+if (result.spanPatches < 1) {
+  failures.push(`Expected ≥1 span patch, got ${result.spanPatches}`);
+}
+
 if (result.totalRequests < 1) {
   failures.push("No requests at all reached the mock Opik server — plugin hooks may not have fired");
+}
+
+if (llmResult.chatCompletions < 1) {
+  failures.push(
+    `Expected ≥1 mock LLM chat completion request, got ${llmResult.chatCompletions}`,
+  );
 }
 
 if (failures.length > 0) {
@@ -37,4 +61,4 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log("[check-e2e] PASS — traces and spans received by mock Opik server");
+console.log("[check-e2e] PASS — traces, spans, patches, and mock LLM traffic were observed");

--- a/scripts/check-e2e-result.mjs
+++ b/scripts/check-e2e-result.mjs
@@ -28,6 +28,7 @@ const llmResult = JSON.parse(fs.readFileSync(LLM_RESULT_FILE, "utf8"));
 console.log("[check-e2e] llm result:", llmResult);
 
 const failures = [];
+const llmGenerationRequests = (llmResult.responses ?? 0) + (llmResult.chatCompletions ?? 0);
 
 if (result.traces < 1) {
   failures.push(`Expected ≥1 trace batch, got ${result.traces}`);
@@ -49,9 +50,9 @@ if (result.totalRequests < 1) {
   failures.push("No requests at all reached the mock Opik server — plugin hooks may not have fired");
 }
 
-if (llmResult.chatCompletions < 1) {
+if (llmGenerationRequests < 1) {
   failures.push(
-    `Expected ≥1 mock LLM chat completion request, got ${llmResult.chatCompletions}`,
+    `Expected ≥1 mock LLM generation request, got ${llmGenerationRequests}`,
   );
 }
 

--- a/scripts/check-e2e-result.mjs
+++ b/scripts/check-e2e-result.mjs
@@ -29,6 +29,8 @@ console.log("[check-e2e] llm result:", llmResult);
 
 const failures = [];
 const llmGenerationRequests = (llmResult.responses ?? 0) + (llmResult.chatCompletions ?? 0);
+const traceFinalizations = (result.tracePatches ?? 0) + (result.endedTraces ?? 0);
+const spanFinalizations = (result.spanPatches ?? 0) + (result.endedSpans ?? 0);
 
 if (result.traces < 1) {
   failures.push(`Expected ≥1 trace batch, got ${result.traces}`);
@@ -38,12 +40,16 @@ if (result.spans < 1) {
   failures.push(`Expected ≥1 span batch, got ${result.spans}`);
 }
 
-if (result.tracePatches < 1) {
-  failures.push(`Expected ≥1 trace patch, got ${result.tracePatches}`);
+if (traceFinalizations < 1) {
+  failures.push(
+    `Expected ≥1 finalized trace (patch or batch endTime), got patches=${result.tracePatches ?? 0} ended=${result.endedTraces ?? 0}`,
+  );
 }
 
-if (result.spanPatches < 1) {
-  failures.push(`Expected ≥1 span patch, got ${result.spanPatches}`);
+if (spanFinalizations < 1) {
+  failures.push(
+    `Expected ≥1 finalized span (patch or batch endTime), got patches=${result.spanPatches ?? 0} ended=${result.endedSpans ?? 0}`,
+  );
 }
 
 if (result.totalRequests < 1) {

--- a/scripts/check-e2e-result.mjs
+++ b/scripts/check-e2e-result.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+/**
+ * Reads the E2E result file written by mock-opik-server.mjs and exits non-zero
+ * if the minimum expected trace/span counts were not met.
+ */
+
+import fs from "node:fs";
+
+const RESULT_FILE = process.env.E2E_RESULT_FILE ?? "e2e-result.json";
+
+if (!fs.existsSync(RESULT_FILE)) {
+  console.error(`[check-e2e] FAIL: result file not found: ${RESULT_FILE}`);
+  console.error("  The mock Opik server may not have written its result (SIGTERM not received?).");
+  process.exit(1);
+}
+
+const result = JSON.parse(fs.readFileSync(RESULT_FILE, "utf8"));
+console.log("[check-e2e] result:", result);
+
+const failures = [];
+
+if (result.traces < 1) {
+  failures.push(`Expected ≥1 trace batch, got ${result.traces}`);
+}
+
+if (result.spans < 1) {
+  failures.push(`Expected ≥1 span batch, got ${result.spans}`);
+}
+
+if (result.totalRequests < 1) {
+  failures.push("No requests at all reached the mock Opik server — plugin hooks may not have fired");
+}
+
+if (failures.length > 0) {
+  console.error("[check-e2e] FAIL:");
+  for (const f of failures) console.error("  •", f);
+  process.exit(1);
+}
+
+console.log("[check-e2e] PASS — traces and spans received by mock Opik server");

--- a/scripts/mock-llm-server.mjs
+++ b/scripts/mock-llm-server.mjs
@@ -16,9 +16,12 @@ import fs from "node:fs";
 const PORT = parseInt(process.env.MOCK_LLM_PORT ?? "18790", 10);
 const MODEL = "gpt-4o-mini";
 const RESULT_FILE = process.env.E2E_LLM_RESULT_FILE ?? "e2e-llm-result.json";
+const RESPONSE_TEXT = "pong";
 
 const received = {
   models: 0,
+  responses: 0,
+  streamingResponses: 0,
   chatCompletions: 0,
   streamingChatCompletions: 0,
 };
@@ -32,7 +35,7 @@ function nonStreamingResponse(model) {
     choices: [
       {
         index: 0,
-        message: { role: "assistant", content: "pong" },
+        message: { role: "assistant", content: RESPONSE_TEXT },
         finish_reason: "stop",
       },
     ],
@@ -46,11 +49,59 @@ function streamingChunks(model) {
 
   const chunks = [
     { id, object: "chat.completion.chunk", created, model, choices: [{ index: 0, delta: { role: "assistant", content: "" }, finish_reason: null }] },
-    { id, object: "chat.completion.chunk", created, model, choices: [{ index: 0, delta: { content: "pong" }, finish_reason: null }] },
+    { id, object: "chat.completion.chunk", created, model, choices: [{ index: 0, delta: { content: RESPONSE_TEXT }, finish_reason: null }] },
     { id, object: "chat.completion.chunk", created, model, choices: [{ index: 0, delta: {}, finish_reason: "stop" }] },
   ];
 
   return chunks.map((c) => `data: ${JSON.stringify(c)}\n\n`).join("") + "data: [DONE]\n\n";
+}
+
+function responseObject(model) {
+  return {
+    id: "resp-e2e-mock",
+    object: "response",
+    created_at: Math.floor(Date.now() / 1000),
+    model,
+    status: "completed",
+    output: [
+      {
+        id: "msg-e2e-mock",
+        type: "message",
+        role: "assistant",
+        content: [
+          {
+            type: "output_text",
+            text: RESPONSE_TEXT,
+            annotations: [],
+          },
+        ],
+      },
+    ],
+    output_text: RESPONSE_TEXT,
+    usage: { input_tokens: 5, output_tokens: 2, total_tokens: 7 },
+  };
+}
+
+function streamingResponseEvents(model) {
+  const response = responseObject(model);
+  const message = response.output[0];
+  const part = message.content[0];
+
+  const events = [
+    ["response.created", { type: "response.created", response: { ...response, status: "in_progress", output: [] } }],
+    ["response.in_progress", { type: "response.in_progress", response: { ...response, status: "in_progress", output: [] } }],
+    ["response.output_item.added", { type: "response.output_item.added", output_index: 0, item: { ...message, content: [] } }],
+    ["response.content_part.added", { type: "response.content_part.added", output_index: 0, item_id: message.id, content_index: 0, part: { type: "output_text", text: "" } }],
+    ["response.output_text.delta", { type: "response.output_text.delta", output_index: 0, item_id: message.id, content_index: 0, delta: RESPONSE_TEXT }],
+    ["response.output_text.done", { type: "response.output_text.done", output_index: 0, item_id: message.id, content_index: 0, text: RESPONSE_TEXT }],
+    ["response.content_part.done", { type: "response.content_part.done", output_index: 0, item_id: message.id, content_index: 0, part }],
+    ["response.output_item.done", { type: "response.output_item.done", output_index: 0, item: message }],
+    ["response.completed", { type: "response.completed", response }],
+  ];
+
+  return events
+    .map(([event, data]) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`)
+    .join("") + "data: [DONE]\n\n";
 }
 
 const server = http.createServer((req, res) => {
@@ -86,6 +137,30 @@ const server = http.createServer((req, res) => {
       } else {
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(nonStreamingResponse(body.model ?? MODEL));
+      }
+      return;
+    }
+
+    if (req.url === "/v1/responses" && req.method === "POST") {
+      let body = {};
+      try { body = JSON.parse(raw); } catch { /* ignore */ }
+
+      const wantsStream = body.stream === true;
+      received.responses += 1;
+      if (wantsStream) {
+        received.streamingResponses += 1;
+      }
+
+      if (wantsStream) {
+        res.writeHead(200, {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+          Connection: "keep-alive",
+        });
+        res.end(streamingResponseEvents(body.model ?? MODEL));
+      } else {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(responseObject(body.model ?? MODEL)));
       }
       return;
     }

--- a/scripts/mock-llm-server.mjs
+++ b/scripts/mock-llm-server.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/**
+ * Minimal OpenAI-compatible mock LLM server for E2E tests.
+ *
+ * Returns a canned chat completion response so the OpenClaw gateway can
+ * complete a full agent turn (llm_input → llm_output → agent_end) without
+ * a real model API key.
+ *
+ * Supports both streaming (SSE) and non-streaming responses because OpenClaw
+ * may request either depending on config.
+ */
+
+import http from "node:http";
+
+const PORT = parseInt(process.env.MOCK_LLM_PORT ?? "18790", 10);
+const MODEL = "gpt-4o-mini";
+
+function nonStreamingResponse(model) {
+  return JSON.stringify({
+    id: "chatcmpl-e2e-mock",
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content: "pong" },
+        finish_reason: "stop",
+      },
+    ],
+    usage: { prompt_tokens: 5, completion_tokens: 2, total_tokens: 7 },
+  });
+}
+
+function streamingChunks(model) {
+  const id = "chatcmpl-e2e-mock";
+  const created = Math.floor(Date.now() / 1000);
+
+  const chunks = [
+    { id, object: "chat.completion.chunk", created, model, choices: [{ index: 0, delta: { role: "assistant", content: "" }, finish_reason: null }] },
+    { id, object: "chat.completion.chunk", created, model, choices: [{ index: 0, delta: { content: "pong" }, finish_reason: null }] },
+    { id, object: "chat.completion.chunk", created, model, choices: [{ index: 0, delta: {}, finish_reason: "stop" }] },
+  ];
+
+  return chunks.map((c) => `data: ${JSON.stringify(c)}\n\n`).join("") + "data: [DONE]\n\n";
+}
+
+const server = http.createServer((req, res) => {
+  let raw = "";
+  req.on("data", (chunk) => (raw += chunk));
+  req.on("end", () => {
+    console.error(`[mock-llm] ${req.method} ${req.url}`);
+
+    if (req.url === "/v1/models" && req.method === "GET") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ object: "list", data: [{ id: MODEL, object: "model" }] }));
+      return;
+    }
+
+    if (req.url === "/v1/chat/completions" && req.method === "POST") {
+      let body = {};
+      try { body = JSON.parse(raw); } catch { /* ignore */ }
+
+      const wantsStream = body.stream === true;
+
+      if (wantsStream) {
+        res.writeHead(200, {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+          Connection: "keep-alive",
+        });
+        res.end(streamingChunks(body.model ?? MODEL));
+      } else {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(nonStreamingResponse(body.model ?? MODEL));
+      }
+      return;
+    }
+
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: { message: "not found", type: "invalid_request_error" } }));
+  });
+});
+
+server.listen(PORT, "127.0.0.1", () => {
+  console.error(`[mock-llm] listening on http://127.0.0.1:${PORT}`);
+});
+
+process.on("SIGTERM", () => server.close(() => process.exit(0)));
+process.on("SIGINT", () => server.close(() => process.exit(0)));

--- a/scripts/mock-llm-server.mjs
+++ b/scripts/mock-llm-server.mjs
@@ -11,9 +11,17 @@
  */
 
 import http from "node:http";
+import fs from "node:fs";
 
 const PORT = parseInt(process.env.MOCK_LLM_PORT ?? "18790", 10);
 const MODEL = "gpt-4o-mini";
+const RESULT_FILE = process.env.E2E_LLM_RESULT_FILE ?? "e2e-llm-result.json";
+
+const received = {
+  models: 0,
+  chatCompletions: 0,
+  streamingChatCompletions: 0,
+};
 
 function nonStreamingResponse(model) {
   return JSON.stringify({
@@ -52,6 +60,7 @@ const server = http.createServer((req, res) => {
     console.error(`[mock-llm] ${req.method} ${req.url}`);
 
     if (req.url === "/v1/models" && req.method === "GET") {
+      received.models += 1;
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ object: "list", data: [{ id: MODEL, object: "model" }] }));
       return;
@@ -62,6 +71,10 @@ const server = http.createServer((req, res) => {
       try { body = JSON.parse(raw); } catch { /* ignore */ }
 
       const wantsStream = body.stream === true;
+      received.chatCompletions += 1;
+      if (wantsStream) {
+        received.streamingChatCompletions += 1;
+      }
 
       if (wantsStream) {
         res.writeHead(200, {
@@ -86,5 +99,17 @@ server.listen(PORT, "127.0.0.1", () => {
   console.error(`[mock-llm] listening on http://127.0.0.1:${PORT}`);
 });
 
-process.on("SIGTERM", () => server.close(() => process.exit(0)));
-process.on("SIGINT", () => server.close(() => process.exit(0)));
+function writeResult() {
+  fs.writeFileSync(RESULT_FILE, JSON.stringify(received, null, 2));
+  console.error(`[mock-llm] result written to ${RESULT_FILE}:`, received);
+}
+
+process.on("SIGTERM", () => {
+  writeResult();
+  server.close(() => process.exit(0));
+});
+
+process.on("SIGINT", () => {
+  writeResult();
+  server.close(() => process.exit(0));
+});

--- a/scripts/mock-opik-server.mjs
+++ b/scripts/mock-opik-server.mjs
@@ -20,6 +20,8 @@ const RESULT_FILE = process.env.E2E_RESULT_FILE ?? "e2e-result.json";
 const received = {
   traces: 0,
   spans: 0,
+  endedTraces: 0,
+  endedSpans: 0,
   tracePatches: 0,
   spanPatches: 0,
   requests: [],
@@ -30,9 +32,13 @@ function record(method, url, body) {
   received.requests.push({ method, url, bodyLength: JSON.stringify(body).length });
 
   if (method === "POST" && url.includes("/traces/batch")) {
-    received.traces += (body?.traces ?? []).length;
+    const traces = body?.traces ?? [];
+    received.traces += traces.length;
+    received.endedTraces += traces.filter((trace) => trace?.endTime !== undefined).length;
   } else if (method === "POST" && url.includes("/spans/batch")) {
-    received.spans += (body?.spans ?? []).length;
+    const spans = body?.spans ?? [];
+    received.spans += spans.length;
+    received.endedSpans += spans.filter((span) => span?.endTime !== undefined).length;
   } else if (method === "PATCH" && url.match(/\/traces\/[^/]+$/)) {
     received.tracePatches += 1;
   } else if (method === "PATCH" && url.match(/\/spans\/[^/]+$/)) {
@@ -80,6 +86,8 @@ function writeResult() {
   const summary = {
     traces: received.traces,
     spans: received.spans,
+    endedTraces: received.endedTraces,
+    endedSpans: received.endedSpans,
     tracePatches: received.tracePatches,
     spanPatches: received.spanPatches,
     totalRequests: received.requests.length,

--- a/scripts/mock-opik-server.mjs
+++ b/scripts/mock-opik-server.mjs
@@ -34,11 +34,11 @@ function record(method, url, body) {
   if (method === "POST" && url.includes("/traces/batch")) {
     const traces = body?.traces ?? [];
     received.traces += traces.length;
-    received.endedTraces += traces.filter((trace) => trace?.endTime !== undefined).length;
+    received.endedTraces += traces.filter((trace) => trace?.endTime !== undefined || trace?.end_time !== undefined).length;
   } else if (method === "POST" && url.includes("/spans/batch")) {
     const spans = body?.spans ?? [];
     received.spans += spans.length;
-    received.endedSpans += spans.filter((span) => span?.endTime !== undefined).length;
+    received.endedSpans += spans.filter((span) => span?.endTime !== undefined || span?.end_time !== undefined).length;
   } else if (method === "PATCH" && url.match(/\/traces\/[^/]+$/)) {
     received.tracePatches += 1;
   } else if (method === "PATCH" && url.match(/\/spans\/[^/]+$/)) {

--- a/scripts/mock-opik-server.mjs
+++ b/scripts/mock-opik-server.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * Mock Opik API server for E2E tests.
+ *
+ * Accepts the Opik trace/span batch and patch endpoints and records every
+ * payload it receives. On SIGTERM (or when the gateway flushes and stops),
+ * it writes a summary to E2E_RESULT_FILE (default: e2e-result.json) and exits.
+ *
+ * The check-e2e-result.mjs script reads that file and fails the test if
+ * no traces or spans were received.
+ */
+
+import http from "node:http";
+import fs from "node:fs";
+import path from "node:path";
+
+const PORT = parseInt(process.env.MOCK_OPIK_PORT ?? "18791", 10);
+const RESULT_FILE = process.env.E2E_RESULT_FILE ?? "e2e-result.json";
+
+const received = {
+  traces: 0,
+  spans: 0,
+  tracePatches: 0,
+  spanPatches: 0,
+  requests: [],
+};
+
+function record(method, url, body) {
+  console.error(`[mock-opik] ${method} ${url}`);
+  received.requests.push({ method, url, bodyLength: JSON.stringify(body).length });
+
+  if (method === "POST" && url.includes("/traces/batch")) {
+    received.traces += (body?.traces ?? []).length;
+  } else if (method === "POST" && url.includes("/spans/batch")) {
+    received.spans += (body?.spans ?? []).length;
+  } else if (method === "PATCH" && url.match(/\/traces\/[^/]+$/)) {
+    received.tracePatches += 1;
+  } else if (method === "PATCH" && url.match(/\/spans\/[^/]+$/)) {
+    received.spanPatches += 1;
+  }
+}
+
+const server = http.createServer((req, res) => {
+  let raw = "";
+  req.on("data", (chunk) => (raw += chunk));
+  req.on("end", () => {
+    let body = {};
+    try {
+      body = JSON.parse(raw || "{}");
+    } catch {
+      // ignore parse errors for non-JSON bodies
+    }
+
+    record(req.method, req.url, body);
+
+    // Respond 200/204 to everything so the plugin doesn't retry.
+    const status =
+      req.method === "GET" ? 200 : req.method === "DELETE" ? 204 : 200;
+
+    res.writeHead(status, { "Content-Type": "application/json" });
+
+    // Return minimal responses for the endpoints Opik SDK reads back.
+    if (req.url?.includes("/projects") && req.method === "GET") {
+      res.end(JSON.stringify({ content: [{ id: "mock-project-id", name: "e2e-test" }] }));
+    } else if (req.url?.includes("/traces/batch") && req.method === "POST") {
+      res.end(JSON.stringify({}));
+    } else if (req.url?.includes("/spans/batch") && req.method === "POST") {
+      res.end(JSON.stringify({}));
+    } else {
+      res.end(JSON.stringify({}));
+    }
+  });
+});
+
+server.listen(PORT, "127.0.0.1", () => {
+  console.error(`[mock-opik] listening on http://127.0.0.1:${PORT}`);
+});
+
+function writeResult() {
+  const summary = {
+    traces: received.traces,
+    spans: received.spans,
+    tracePatches: received.tracePatches,
+    spanPatches: received.spanPatches,
+    totalRequests: received.requests.length,
+  };
+  fs.writeFileSync(RESULT_FILE, JSON.stringify(summary, null, 2));
+  console.error(`[mock-opik] result written to ${RESULT_FILE}:`, summary);
+}
+
+process.on("SIGTERM", () => {
+  writeResult();
+  server.close(() => process.exit(0));
+});
+
+process.on("SIGINT", () => {
+  writeResult();
+  server.close(() => process.exit(0));
+});


### PR DESCRIPTION
## Problem

Unit tests can't catch the class of bug fixed in #59 — hooks silently dropped due to OpenClaw plugin lifecycle changes. OpenClaw moves fast; we need a test that will break if a future OpenClaw release breaks the plugin again.

## What this adds

A self-contained E2E workflow (`.github/workflows/e2e.yml`) that:

1. **Installs the latest published OpenClaw** (`npm install -g openclaw@latest`)
2. **Builds the plugin from source** and installs the tarball into OpenClaw
3. **Starts a mock Opik server** (`scripts/mock-opik-server.mjs`) that captures all trace/span API calls
4. **Starts a mock LLM server** (`scripts/mock-llm-server.mjs`) — OpenAI-compatible, returns a canned response so no real API key is needed
5. **Runs a real gateway turn** (`openclaw agent --message "ping"`)
6. **Asserts** that the mock Opik server received ≥1 trace batch and ≥1 span batch

If the PR #59 regression had existed, step 6 would have caught it — zero traces would have reached the mock server.

## No secrets required

Both LLM and Opik are mocked locally. The workflow is fully self-contained.

## Matrix

The workflow runs against `openclaw@latest` today. The matrix can be extended to pin specific versions as OpenClaw ships new releases.

## Files

| File | Purpose |
|------|---------|
| `.github/workflows/e2e.yml` | CI workflow |
| `scripts/mock-opik-server.mjs` | Captures Opik API calls, writes `e2e-result.json` |
| `scripts/mock-llm-server.mjs` | OpenAI-compatible mock, supports streaming + non-streaming |
| `scripts/check-e2e-result.mjs` | Reads result file, exits non-zero if traces/spans missing |