### PR TITLE
test(ci): add mock request journals for e2e

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,6 +47,8 @@ jobs:
     env:
       E2E_RESULT_FILE: e2e-result.json
       E2E_LLM_RESULT_FILE: e2e-llm-result.json
+      E2E_OPIK_JOURNAL_FILE: e2e-opik-journal.json
+      E2E_LLM_JOURNAL_FILE: e2e-llm-journal.json
       OPENCLAW_GATEWAY_TOKEN: e2e-test-token
 
     steps:
@@ -246,6 +248,8 @@ jobs:
           path: |
             e2e-result.json
             e2e-llm-result.json
+            e2e-opik-journal.json
+            e2e-llm-journal.json
             agent-output.log
             gateway.log
             mock-opik.log

--- a/scripts/check-e2e-result.mjs
+++ b/scripts/check-e2e-result.mjs
@@ -8,6 +8,31 @@ import fs from "node:fs";
 
 const RESULT_FILE = process.env.E2E_RESULT_FILE ?? "e2e-result.json";
 const LLM_RESULT_FILE = process.env.E2E_LLM_RESULT_FILE ?? "e2e-llm-result.json";
+const OPIK_JOURNAL_FILE = process.env.E2E_OPIK_JOURNAL_FILE ?? "e2e-opik-journal.json";
+const LLM_JOURNAL_FILE = process.env.E2E_LLM_JOURNAL_FILE ?? "e2e-llm-journal.json";
+
+function readJsonIfExists(file) {
+  return fs.existsSync(file) ? JSON.parse(fs.readFileSync(file, "utf8")) : null;
+}
+
+function formatRecentRequests(label, journal) {
+  if (!journal?.requests?.length) {
+    return `  ${label}: no journal entries (${label === "Opik" ? OPIK_JOURNAL_FILE : LLM_JOURNAL_FILE})`;
+  }
+  const recent = journal.requests.slice(-3);
+  const lines = recent.map((entry) => {
+    const summary =
+      entry.route === "traces-batch"
+        ? `traceCount=${entry.traceCount ?? 0} finalized=${entry.finalizedTraceCount ?? 0}`
+        : entry.route === "spans-batch"
+          ? `spanCount=${entry.spanCount ?? 0} finalized=${entry.finalizedSpanCount ?? 0}`
+          : entry.route === "responses" || entry.route === "chat-completions"
+            ? `model=${entry.model ?? "unknown"} stream=${entry.stream === true}`
+            : "";
+    return `    - ${entry.method} ${entry.url} route=${entry.route}${summary ? ` ${summary}` : ""}`;
+  });
+  return [`  ${label} journal: ${label === "Opik" ? OPIK_JOURNAL_FILE : LLM_JOURNAL_FILE}`, ...lines].join("\n");
+}
 
 if (!fs.existsSync(RESULT_FILE)) {
   console.error(`[check-e2e] FAIL: result file not found: ${RESULT_FILE}`);
@@ -26,6 +51,8 @@ if (!fs.existsSync(LLM_RESULT_FILE)) {
 
 const llmResult = JSON.parse(fs.readFileSync(LLM_RESULT_FILE, "utf8"));
 console.log("[check-e2e] llm result:", llmResult);
+const opikJournal = readJsonIfExists(OPIK_JOURNAL_FILE);
+const llmJournal = readJsonIfExists(LLM_JOURNAL_FILE);
 
 const failures = [];
 const llmGenerationRequests = (llmResult.responses ?? 0) + (llmResult.chatCompletions ?? 0);
@@ -65,6 +92,8 @@ if (llmGenerationRequests < 1) {
 if (failures.length > 0) {
   console.error("[check-e2e] FAIL:");
   for (const f of failures) console.error("  •", f);
+  console.error(formatRecentRequests("Opik", opikJournal));
+  console.error(formatRecentRequests("LLM", llmJournal));
   process.exit(1);
 }
 

--- a/scripts/mock-llm-server.mjs
+++ b/scripts/mock-llm-server.mjs
@@ -16,6 +16,7 @@ import fs from "node:fs";
 const PORT = parseInt(process.env.MOCK_LLM_PORT ?? "18790", 10);
 const MODEL = "gpt-4o-mini";
 const RESULT_FILE = process.env.E2E_LLM_RESULT_FILE ?? "e2e-llm-result.json";
+const JOURNAL_FILE = process.env.E2E_LLM_JOURNAL_FILE ?? "e2e-llm-journal.json";
 const RESPONSE_TEXT = "pong";
 
 const received = {
@@ -24,7 +25,31 @@ const received = {
   streamingResponses: 0,
   chatCompletions: 0,
   streamingChatCompletions: 0,
+  requests: [],
 };
+
+function redactHeaders(headers) {
+  const entries = Object.entries(headers ?? {});
+  return Object.fromEntries(
+    entries.map(([key, value]) => {
+      if (key.toLowerCase() === "authorization") {
+        return [key, "<redacted>"];
+      }
+      return [key, value];
+    }),
+  );
+}
+
+function recordRequest(req, body, summary) {
+  received.requests.push({
+    at: new Date().toISOString(),
+    method: req.method,
+    url: req.url,
+    headers: redactHeaders(req.headers),
+    body,
+    ...summary,
+  });
+}
 
 function nonStreamingResponse(model) {
   return JSON.stringify({
@@ -112,6 +137,7 @@ const server = http.createServer((req, res) => {
 
     if (req.url === "/v1/models" && req.method === "GET") {
       received.models += 1;
+      recordRequest(req, undefined, { route: "models-list" });
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ object: "list", data: [{ id: MODEL, object: "model" }] }));
       return;
@@ -126,6 +152,12 @@ const server = http.createServer((req, res) => {
       if (wantsStream) {
         received.streamingChatCompletions += 1;
       }
+      recordRequest(req, body, {
+        route: "chat-completions",
+        stream: wantsStream,
+        model: body.model ?? MODEL,
+        inputShape: Array.isArray(body.messages) ? "messages" : typeof body.input,
+      });
 
       if (wantsStream) {
         res.writeHead(200, {
@@ -150,6 +182,12 @@ const server = http.createServer((req, res) => {
       if (wantsStream) {
         received.streamingResponses += 1;
       }
+      recordRequest(req, body, {
+        route: "responses",
+        stream: wantsStream,
+        model: body.model ?? MODEL,
+        inputShape: Array.isArray(body.input) ? "input[]" : typeof body.input,
+      });
 
       if (wantsStream) {
         res.writeHead(200, {
@@ -165,6 +203,7 @@ const server = http.createServer((req, res) => {
       return;
     }
 
+    recordRequest(req, body, { route: "not-found" });
     res.writeHead(404, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ error: { message: "not found", type: "invalid_request_error" } }));
   });
@@ -175,8 +214,22 @@ server.listen(PORT, "127.0.0.1", () => {
 });
 
 function writeResult() {
-  fs.writeFileSync(RESULT_FILE, JSON.stringify(received, null, 2));
-  console.error(`[mock-llm] result written to ${RESULT_FILE}:`, received);
+  const summary = {
+    models: received.models,
+    responses: received.responses,
+    streamingResponses: received.streamingResponses,
+    chatCompletions: received.chatCompletions,
+    streamingChatCompletions: received.streamingChatCompletions,
+    totalRequests: received.requests.length,
+  };
+  fs.writeFileSync(RESULT_FILE, JSON.stringify(summary, null, 2));
+  console.error(`[mock-llm] result written to ${RESULT_FILE}:`, summary);
+  const journal = {
+    summary,
+    requests: received.requests,
+  };
+  fs.writeFileSync(JOURNAL_FILE, JSON.stringify(journal, null, 2));
+  console.error(`[mock-llm] journal written to ${JOURNAL_FILE}`);
 }
 
 process.on("SIGTERM", () => {

--- a/scripts/mock-opik-server.mjs
+++ b/scripts/mock-opik-server.mjs
@@ -16,6 +16,7 @@ import path from "node:path";
 
 const PORT = parseInt(process.env.MOCK_OPIK_PORT ?? "18791", 10);
 const RESULT_FILE = process.env.E2E_RESULT_FILE ?? "e2e-result.json";
+const JOURNAL_FILE = process.env.E2E_OPIK_JOURNAL_FILE ?? "e2e-opik-journal.json";
 
 const received = {
   traces: 0,
@@ -27,9 +28,66 @@ const received = {
   requests: [],
 };
 
-function record(method, url, body) {
+function redactHeaders(headers) {
+  const entries = Object.entries(headers ?? {});
+  return Object.fromEntries(
+    entries.map(([key, value]) => {
+      if (key.toLowerCase() === "authorization") {
+        return [key, "<redacted>"];
+      }
+      return [key, value];
+    }),
+  );
+}
+
+function buildRequestSummary(method, url, body) {
+  if (method === "POST" && url.includes("/traces/batch")) {
+    const traces = body?.traces ?? [];
+    return {
+      route: "traces-batch",
+      traceCount: traces.length,
+      finalizedTraceCount: traces.filter(
+        (trace) => trace?.endTime !== undefined || trace?.end_time !== undefined,
+      ).length,
+      traceIds: traces.map((trace) => trace?.id).filter(Boolean).slice(0, 5),
+    };
+  }
+  if (method === "POST" && url.includes("/spans/batch")) {
+    const spans = body?.spans ?? [];
+    return {
+      route: "spans-batch",
+      spanCount: spans.length,
+      finalizedSpanCount: spans.filter(
+        (span) => span?.endTime !== undefined || span?.end_time !== undefined,
+      ).length,
+      spanIds: spans.map((span) => span?.id).filter(Boolean).slice(0, 5),
+    };
+  }
+  if (method === "PATCH" && url.match(/\/traces\/[^/]+$/)) {
+    return { route: "trace-patch" };
+  }
+  if (method === "PATCH" && url.match(/\/spans\/[^/]+$/)) {
+    return { route: "span-patch" };
+  }
+  if (method === "GET" && url.includes("/projects")) {
+    return { route: "projects-list" };
+  }
+  return { route: "other" };
+}
+
+function record(method, url, body, headers) {
   console.error(`[mock-opik] ${method} ${url}`);
-  received.requests.push({ method, url, bodyLength: JSON.stringify(body).length });
+  const encodedBody = JSON.stringify(body);
+  const summary = buildRequestSummary(method, url, body);
+  received.requests.push({
+    at: new Date().toISOString(),
+    method,
+    url,
+    headers: redactHeaders(headers),
+    bodyLength: encodedBody.length,
+    body,
+    ...summary,
+  });
 
   if (method === "POST" && url.includes("/traces/batch")) {
     const traces = body?.traces ?? [];
@@ -57,7 +115,7 @@ const server = http.createServer((req, res) => {
       // ignore parse errors for non-JSON bodies
     }
 
-    record(req.method, req.url, body);
+    record(req.method, req.url, body, req.headers);
 
     // Respond 200/204 to everything so the plugin doesn't retry.
     const status =
@@ -94,6 +152,12 @@ function writeResult() {
   };
   fs.writeFileSync(RESULT_FILE, JSON.stringify(summary, null, 2));
   console.error(`[mock-opik] result written to ${RESULT_FILE}:`, summary);
+  const journal = {
+    summary,
+    requests: received.requests,
+  };
+  fs.writeFileSync(JOURNAL_FILE, JSON.stringify(journal, null, 2));
+  console.error(`[mock-opik] journal written to ${JOURNAL_FILE}`);
 }
 
 process.on("SIGTERM", () => {


### PR DESCRIPTION
## Summary
- write structured request journals for both mock Opik and mock LLM servers
- redact auth headers but keep full request bodies and route summaries for CI debugging
- surface the last few journal entries in `check-e2e-result.mjs` when the e2e assertion fails
- upload the new journal artifacts on workflow failure

## Validation
- `npm test`
- `npm run typecheck`
- manual smoke of both mock servers plus `node scripts/check-e2e-result.mjs`
