### PR TITLE
test(e2e): add a local live gateway harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,15 +60,15 @@ jobs:
       - name: Run smoke tests
         run: npm run smoke
 
-      # - name: Run E2E tests
-      #   if: ${{ secrets.OPIK_API_KEY != '' }}
+      # - name: Run live gateway E2E
+      #   if: ${{ secrets.OPIK_API_KEY != '' && secrets.OPENAI_API_KEY != '' }}
       #   env:
-      #     OPIK_E2E: "1"
+      #     OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       #     OPIK_API_KEY: ${{ secrets.OPIK_API_KEY }}
       #     OPIK_URL_OVERRIDE: ${{ secrets.OPIK_URL_OVERRIDE || 'https://www.comet.com/opik/api' }}
       #     OPIK_PROJECT_NAME: ${{ secrets.OPIK_PROJECT_NAME || 'openclaw' }}
       #     OPIK_WORKSPACE: ${{ secrets.OPIK_WORKSPACE || 'default' }}
-      #   run: npm run test:e2e
+      #   run: npm run test:live
 
       - name: Verify package payload
         run: npm pack --dry-run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,15 +60,5 @@ jobs:
       - name: Run smoke tests
         run: npm run smoke
 
-      # - name: Run live gateway E2E
-      #   if: ${{ secrets.OPIK_API_KEY != '' && secrets.OPENAI_API_KEY != '' }}
-      #   env:
-      #     OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      #     OPIK_API_KEY: ${{ secrets.OPIK_API_KEY }}
-      #     OPIK_URL_OVERRIDE: ${{ secrets.OPIK_URL_OVERRIDE || 'https://www.comet.com/opik/api' }}
-      #     OPIK_PROJECT_NAME: ${{ secrets.OPIK_PROJECT_NAME || 'openclaw' }}
-      #     OPIK_WORKSPACE: ${{ secrets.OPIK_WORKSPACE || 'default' }}
-      #   run: npm run test:live
-
       - name: Verify package payload
         run: npm pack --dry-run

--- a/README.md
+++ b/README.md
@@ -182,17 +182,14 @@ npm run smoke
 Optional live gateway E2E:
 
 ```bash
-OPENAI_API_KEY=... \
-OPIK_API_KEY=... \
-OPIK_URL_OVERRIDE=https://www.comet.com/opik/api \
-OPIK_PROJECT_NAME=openclaw \
-OPIK_WORKSPACE=default \
 npm run test:live
 ```
 
 Notes:
 
 - uses an isolated `.artifacts/live-e2e/<run-id>/home/.openclaw` so it does not touch your normal OpenClaw config
+- reuses `~/.openclaw/openclaw.json -> plugins.entries.opik-openclaw.config` for `apiUrl` / `apiKey` / project / workspace when those env vars are not set
+- still requires `OPENAI_API_KEY` in env for the real model call
 - packs and installs the current plugin build into a fresh OpenClaw home
 - falls back to `npx openclaw@${OPENCLAW_LIVE_OPENCLAW_VERSION:-2026.4.15}` when `openclaw` is not already on your `PATH`
 - override the live model with `OPENCLAW_LIVE_MODEL` if `gpt-4o-mini` is not what you want to exercise

--- a/README.md
+++ b/README.md
@@ -188,7 +188,9 @@ npm run test:live
 Notes:
 
 - uses an isolated `.artifacts/live-e2e/<run-id>/home/.openclaw` so it does not touch your normal OpenClaw config
-- reuses `~/.openclaw/openclaw.json -> plugins.entries.opik-openclaw.config` for `apiUrl` / `apiKey` / project / workspace when those env vars are not set
+- `OPIK_API_KEY`, `OPIK_URL_OVERRIDE`, `OPIK_PROJECT_NAME`, and `OPIK_WORKSPACE` win if set in env
+- otherwise it reuses `~/.openclaw/openclaw.json -> plugins.entries.opik-openclaw.config` for `apiUrl` / `apiKey` / project / workspace
+- set `OPENCLAW_LIVE_USE_HOST_OPIK_CONFIG=0` to disable reading host plugin config and require explicit env-only Opik settings
 - still requires `OPENAI_API_KEY` in env for the real model call
 - packs and installs the current plugin build into a fresh OpenClaw home
 - falls back to `npx openclaw@${OPENCLAW_LIVE_OPENCLAW_VERSION:-2026.4.15}` when `openclaw` is not already on your `PATH`

--- a/README.md
+++ b/README.md
@@ -179,6 +179,24 @@ npm run test
 npm run smoke
 ```
 
+Optional live gateway E2E:
+
+```bash
+OPENAI_API_KEY=... \
+OPIK_API_KEY=... \
+OPIK_URL_OVERRIDE=https://www.comet.com/opik/api \
+OPIK_PROJECT_NAME=openclaw \
+OPIK_WORKSPACE=default \
+npm run test:live
+```
+
+Notes:
+
+- uses an isolated `.artifacts/live-e2e/<run-id>/home/.openclaw` so it does not touch your normal OpenClaw config
+- packs and installs the current plugin build into a fresh OpenClaw home
+- falls back to `npx openclaw@${OPENCLAW_LIVE_OPENCLAW_VERSION:-2026.4.15}` when `openclaw` is not already on your `PATH`
+- override the live model with `OPENCLAW_LIVE_MODEL` if `gpt-4o-mini` is not what you want to exercise
+
 ## Contributing
 
 Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a PR.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:e2e": "vitest run src/**/*.e2e.test.ts",
+    "test:live": "node scripts/live-e2e.mjs",
     "smoke": "vitest run src/plugin.smoke.test.ts"
   },
   "dependencies": {

--- a/scripts/live-e2e.mjs
+++ b/scripts/live-e2e.mjs
@@ -1,0 +1,320 @@
+#!/usr/bin/env node
+
+import { randomUUID } from "node:crypto";
+import { spawn, spawnSync } from "node:child_process";
+import { createWriteStream } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Opik } from "opik";
+
+const ROOT_DIR = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const REQUIRED_ENV = ["OPENAI_API_KEY", "OPIK_API_KEY", "OPIK_URL_OVERRIDE"];
+const missingEnv = REQUIRED_ENV.filter((key) => !process.env[key]?.trim());
+
+if (missingEnv.length > 0) {
+  console.error(
+    `[live-e2e] missing required env: ${missingEnv.join(", ")}\n` +
+      "Set the live OpenAI + Opik credentials, then rerun `npm run test:live`.",
+  );
+  process.exit(1);
+}
+
+const runId = `live-e2e-${Date.now()}-${randomUUID().slice(0, 8)}`;
+const artifactDir = path.join(ROOT_DIR, ".artifacts", "live-e2e", runId);
+const homeDir = path.join(artifactDir, "home");
+const openclawDir = path.join(homeDir, ".openclaw");
+const configPath = path.join(openclawDir, "openclaw.json");
+const gatewayLogPath = path.join(artifactDir, "gateway.log");
+const agentOutputPath = path.join(artifactDir, "agent-output.log");
+const tracesPath = path.join(artifactDir, "opik-traces.json");
+const spansPath = path.join(artifactDir, "opik-spans.json");
+
+const gatewayPort = Number.parseInt(process.env.OPENCLAW_LIVE_GATEWAY_PORT ?? "18789", 10);
+const gatewayToken = process.env.OPENCLAW_GATEWAY_TOKEN?.trim() || `live-${randomUUID()}`;
+const opikProjectName = process.env.OPIK_PROJECT_NAME?.trim() || "openclaw";
+const opikWorkspaceName = process.env.OPIK_WORKSPACE?.trim() || "default";
+const liveModel = process.env.OPENCLAW_LIVE_MODEL?.trim() || "gpt-4o-mini";
+const requestedOpenClawVersion = process.env.OPENCLAW_LIVE_OPENCLAW_VERSION?.trim() || "2026.4.15";
+const promptToken = `token-${randomUUID().slice(0, 8)}`;
+const agentMessage = `Reply with the single word pong. Preserve token ${promptToken}.`;
+let opikSearchStartTime = new Date().toISOString();
+
+const openclawInvocation = resolveOpenClawInvocation(requestedOpenClawVersion);
+const openclawEnv = {
+  ...process.env,
+  HOME: homeDir,
+  OPENCLAW_GATEWAY_TOKEN: gatewayToken,
+};
+
+await fs.mkdir(openclawDir, { recursive: true });
+await fs.mkdir(artifactDir, { recursive: true });
+
+const pluginTarballPath = await packPlugin();
+await writeOpenClawConfig();
+
+let gatewayProcess;
+
+try {
+  await runCommand(["plugins", "install", pluginTarballPath], {
+    env: openclawEnv,
+    name: "openclaw plugins install",
+  });
+
+  gatewayProcess = startDetachedProcess(["gateway", "run"], gatewayLogPath);
+  await waitForGateway();
+
+  opikSearchStartTime = new Date().toISOString();
+  const agentRun = await runCommand(
+    ["agent", "--agent", "main", "--message", agentMessage, "--deliver"],
+    {
+      env: openclawEnv,
+      name: "openclaw agent",
+      captureOutput: true,
+    },
+  );
+  await fs.writeFile(agentOutputPath, agentRun.output, "utf8");
+
+  if (agentRun.output.includes("falling back to embedded")) {
+    throw new Error("gateway turn fell back to embedded mode");
+  }
+  if (!agentRun.output.toLowerCase().includes("pong")) {
+    throw new Error("agent output did not contain the expected pong response");
+  }
+
+  const { traces, spans } = await verifyOpikExport();
+  await fs.writeFile(tracesPath, JSON.stringify(traces, null, 2), "utf8");
+  await fs.writeFile(spansPath, JSON.stringify(spans, null, 2), "utf8");
+
+  console.log(
+    `[live-e2e] PASS runId=${runId} traces=${traces.length} spans=${spans.length} artifacts=${artifactDir}`,
+  );
+} catch (error) {
+  console.error(`[live-e2e] FAIL: ${formatError(error)}`);
+  console.error(`[live-e2e] artifacts: ${artifactDir}`);
+  process.exitCode = 1;
+} finally {
+  await stopGateway(gatewayProcess);
+}
+
+async function packPlugin() {
+  const pack = await runCommand(["pack", "--pack-destination", artifactDir], {
+    env: process.env,
+    name: "npm pack",
+    spawnCommand: "npm",
+    captureOutput: true,
+  });
+  const tarball = pack.output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .find((line) => line.endsWith(".tgz"));
+  if (!tarball) {
+    throw new Error(`npm pack did not report a tarball path:\n${pack.output}`);
+  }
+  return path.join(artifactDir, tarball);
+}
+
+async function writeOpenClawConfig() {
+  const config = {
+    gateway: {
+      mode: "local",
+      bind: "loopback",
+      auth: { mode: "token", token: gatewayToken },
+      port: gatewayPort,
+    },
+    agents: {
+      defaults: {
+        model: {
+          primary: `openai/${liveModel}`,
+        },
+      },
+    },
+    plugins: {
+      allow: ["opik-openclaw"],
+      entries: {
+        "opik-openclaw": {
+          enabled: true,
+          config: {
+            enabled: true,
+            apiUrl: process.env.OPIK_URL_OVERRIDE,
+            apiKey: process.env.OPIK_API_KEY,
+            projectName: opikProjectName,
+            workspaceName: opikWorkspaceName,
+            tags: ["live-e2e"],
+          },
+        },
+      },
+    },
+  };
+  await fs.writeFile(configPath, JSON.stringify(config, null, 2), "utf8");
+}
+
+function resolveOpenClawInvocation(version) {
+  const explicitBin = process.env.OPENCLAW_LIVE_BIN?.trim();
+  if (explicitBin) {
+    return { command: explicitBin, baseArgs: [] };
+  }
+  const direct = spawnSync("openclaw", ["--version"], { stdio: "ignore" });
+  if (direct.status === 0) {
+    return { command: "openclaw", baseArgs: [] };
+  }
+  return { command: "npx", baseArgs: ["-y", `openclaw@${version}`] };
+}
+
+function startDetachedProcess(args, logPath) {
+  const logStream = createWriteStream(logPath, { flags: "a" });
+  const child = spawn(openclawInvocation.command, [...openclawInvocation.baseArgs, ...args], {
+    cwd: ROOT_DIR,
+    env: openclawEnv,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stdout?.pipe(logStream);
+  child.stderr?.pipe(logStream);
+  child.on("close", () => {
+    logStream.end();
+  });
+  return child;
+}
+
+async function waitForGateway() {
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    const health = await runCommand(["health"], {
+      env: openclawEnv,
+      name: "openclaw health",
+      allowFailure: true,
+      captureOutput: true,
+    });
+    if (health.code === 0) {
+      return;
+    }
+    await sleep(1000);
+  }
+  throw new Error(`gateway failed to become ready; see ${gatewayLogPath}`);
+}
+
+async function stopGateway(gateway) {
+  await runCommand(["gateway", "stop"], {
+    env: openclawEnv,
+    name: "openclaw gateway stop",
+    allowFailure: true,
+  });
+
+  if (!gateway) {
+    return;
+  }
+
+  if (gateway.exitCode === null) {
+    gateway.kill("SIGTERM");
+    await Promise.race([
+      new Promise((resolve) => gateway.once("close", resolve)),
+      sleep(5000),
+    ]);
+  }
+  if (gateway.exitCode === null) {
+    gateway.kill("SIGKILL");
+  }
+}
+
+async function verifyOpikExport() {
+  const client = new Opik({
+    apiKey: process.env.OPIK_API_KEY,
+    apiUrl: process.env.OPIK_URL_OVERRIDE,
+    projectName: opikProjectName,
+    workspaceName: opikWorkspaceName,
+  });
+
+  const startedAtFilter = escapeOqlString(opikSearchStartTime);
+  const traceFilter = `metadata.created_from = "openclaw" AND start_time >= "${startedAtFilter}"`;
+
+  const traces = await client.searchTraces({
+    projectName: opikProjectName,
+    filterString: traceFilter,
+    waitForAtLeast: 1,
+    waitForTimeout: 90,
+    maxResults: 20,
+  });
+  const matchingTrace = traces.find((trace) => serializedContains(trace.input, promptToken));
+  if (!matchingTrace) {
+    throw new Error(`no live Opik traces matched filter: ${traceFilter}`);
+  }
+
+  const spanFilter = `start_time >= "${startedAtFilter}"`;
+  const spans = await client.searchSpans({
+    projectName: opikProjectName,
+    filterString: spanFilter,
+    waitForAtLeast: 1,
+    waitForTimeout: 90,
+    maxResults: 30,
+  });
+  const matchingSpans = spans.filter(
+    (span) =>
+      (matchingTrace.id && span.traceId === matchingTrace.id) ||
+      serializedContains(span.input, promptToken),
+  );
+  if (matchingSpans.length < 1) {
+    throw new Error(`no live Opik spans matched filter: ${spanFilter}`);
+  }
+
+  return { traces: [matchingTrace], spans: matchingSpans };
+}
+
+function escapeOqlString(value) {
+  return value.replaceAll("\\", "\\\\").replaceAll("\"", "\\\"");
+}
+
+function serializedContains(value, token) {
+  if (value === undefined || value === null) {
+    return false;
+  }
+  return JSON.stringify(value).includes(token);
+}
+
+async function runCommand(args, options) {
+  const command = options.spawnCommand ?? openclawInvocation.command;
+  const fullArgs =
+    options.spawnCommand === undefined
+      ? [...openclawInvocation.baseArgs, ...args]
+      : args;
+
+  return await new Promise((resolve, reject) => {
+    const child = spawn(command, fullArgs, {
+      cwd: ROOT_DIR,
+      env: options.env,
+      stdio: options.captureOutput ? ["ignore", "pipe", "pipe"] : "inherit",
+    });
+
+    let output = "";
+    if (options.captureOutput) {
+      child.stdout?.on("data", (chunk) => {
+        output += chunk.toString();
+      });
+      child.stderr?.on("data", (chunk) => {
+        output += chunk.toString();
+      });
+    }
+
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code !== 0 && !options.allowFailure) {
+        reject(
+          new Error(
+            `${options.name} failed with exit code ${code}\n${
+              options.captureOutput ? output : ""
+            }`,
+          ),
+        );
+        return;
+      }
+      resolve({ code: code ?? 0, output });
+    });
+  });
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function formatError(error) {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/scripts/live-e2e.mjs
+++ b/scripts/live-e2e.mjs
@@ -9,13 +9,32 @@ import { fileURLToPath } from "node:url";
 import { Opik } from "opik";
 
 const ROOT_DIR = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
-const REQUIRED_ENV = ["OPENAI_API_KEY", "OPIK_API_KEY", "OPIK_URL_OVERRIDE"];
-const missingEnv = REQUIRED_ENV.filter((key) => !process.env[key]?.trim());
+const hostHomeDir = process.env.HOME ?? "";
+const hostOpenClawConfigPath = path.join(hostHomeDir, ".openclaw", "openclaw.json");
+const hostOpenClawConfig = await readJsonIfExists(hostOpenClawConfigPath);
+const hostOpikPluginConfig = hostOpenClawConfig?.plugins?.entries?.["opik-openclaw"]?.config;
 
-if (missingEnv.length > 0) {
+const openAiApiKey = process.env.OPENAI_API_KEY?.trim();
+const opikApiKey = process.env.OPIK_API_KEY?.trim() ?? trimOrUndefined(hostOpikPluginConfig?.apiKey);
+const opikApiUrl =
+  process.env.OPIK_URL_OVERRIDE?.trim() ?? trimOrUndefined(hostOpikPluginConfig?.apiUrl);
+
+const missingRequirements = [];
+if (!openAiApiKey) {
+  missingRequirements.push("OPENAI_API_KEY");
+}
+if (!opikApiKey) {
+  missingRequirements.push("OPIK_API_KEY or ~/.openclaw/openclaw.json plugins.entries.opik-openclaw.config.apiKey");
+}
+if (!opikApiUrl) {
+  missingRequirements.push(
+    "OPIK_URL_OVERRIDE or ~/.openclaw/openclaw.json plugins.entries.opik-openclaw.config.apiUrl",
+  );
+}
+if (missingRequirements.length > 0) {
   console.error(
-    `[live-e2e] missing required env: ${missingEnv.join(", ")}\n` +
-      "Set the live OpenAI + Opik credentials, then rerun `npm run test:live`.",
+    `[live-e2e] missing required live config:\n- ${missingRequirements.join("\n- ")}\n` +
+      "Set env vars or configure the installed opik-openclaw plugin in ~/.openclaw/openclaw.json.",
   );
   process.exit(1);
 }
@@ -32,8 +51,14 @@ const spansPath = path.join(artifactDir, "opik-spans.json");
 
 const gatewayPort = Number.parseInt(process.env.OPENCLAW_LIVE_GATEWAY_PORT ?? "18789", 10);
 const gatewayToken = process.env.OPENCLAW_GATEWAY_TOKEN?.trim() || `live-${randomUUID()}`;
-const opikProjectName = process.env.OPIK_PROJECT_NAME?.trim() || "openclaw";
-const opikWorkspaceName = process.env.OPIK_WORKSPACE?.trim() || "default";
+const opikProjectName =
+  process.env.OPIK_PROJECT_NAME?.trim() ??
+  trimOrUndefined(hostOpikPluginConfig?.projectName) ??
+  "openclaw";
+const opikWorkspaceName =
+  process.env.OPIK_WORKSPACE?.trim() ??
+  trimOrUndefined(hostOpikPluginConfig?.workspaceName) ??
+  "default";
 const liveModel = process.env.OPENCLAW_LIVE_MODEL?.trim() || "gpt-4o-mini";
 const requestedOpenClawVersion = process.env.OPENCLAW_LIVE_OPENCLAW_VERSION?.trim() || "2026.4.15";
 const promptToken = `token-${randomUUID().slice(0, 8)}`;
@@ -45,13 +70,14 @@ const openclawEnv = {
   ...process.env,
   HOME: homeDir,
   OPENCLAW_GATEWAY_TOKEN: gatewayToken,
+  OPENAI_API_KEY: openAiApiKey,
 };
 
 await fs.mkdir(openclawDir, { recursive: true });
 await fs.mkdir(artifactDir, { recursive: true });
 
 const pluginTarballPath = await packPlugin();
-await writeOpenClawConfig();
+await writeOpenClawConfig({ enablePlugin: false });
 
 let gatewayProcess;
 
@@ -60,13 +86,14 @@ try {
     env: openclawEnv,
     name: "openclaw plugins install",
   });
+  await writeOpenClawConfig({ enablePlugin: true });
 
   gatewayProcess = startDetachedProcess(["gateway", "run"], gatewayLogPath);
   await waitForGateway();
 
   opikSearchStartTime = new Date().toISOString();
   const agentRun = await runCommand(
-    ["agent", "--agent", "main", "--message", agentMessage, "--deliver"],
+    ["agent", "--agent", "main", "--message", agentMessage],
     {
       env: openclawEnv,
       name: "openclaw agent",
@@ -98,24 +125,20 @@ try {
 }
 
 async function packPlugin() {
-  const pack = await runCommand(["pack", "--pack-destination", artifactDir], {
+  const pack = await runCommand(["pack", "--json", "--pack-destination", artifactDir], {
     env: process.env,
     name: "npm pack",
     spawnCommand: "npm",
     captureOutput: true,
   });
-  const tarball = pack.output
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .find((line) => line.endsWith(".tgz"));
-  if (!tarball) {
+  const tarball = JSON.parse(pack.output)?.[0]?.filename;
+  if (typeof tarball !== "string" || !tarball.endsWith(".tgz")) {
     throw new Error(`npm pack did not report a tarball path:\n${pack.output}`);
   }
   return path.join(artifactDir, tarball);
 }
 
-async function writeOpenClawConfig() {
+async function writeOpenClawConfig(params) {
   const config = {
     gateway: {
       mode: "local",
@@ -130,23 +153,25 @@ async function writeOpenClawConfig() {
         },
       },
     },
-    plugins: {
+  };
+  if (params.enablePlugin) {
+    config.plugins = {
       allow: ["opik-openclaw"],
       entries: {
         "opik-openclaw": {
           enabled: true,
           config: {
             enabled: true,
-            apiUrl: process.env.OPIK_URL_OVERRIDE,
-            apiKey: process.env.OPIK_API_KEY,
+            apiUrl: opikApiUrl,
+            apiKey: opikApiKey,
             projectName: opikProjectName,
             workspaceName: opikWorkspaceName,
             tags: ["live-e2e"],
           },
         },
       },
-    },
-  };
+    };
+  }
   await fs.writeFile(configPath, JSON.stringify(config, null, 2), "utf8");
 }
 
@@ -218,8 +243,8 @@ async function stopGateway(gateway) {
 
 async function verifyOpikExport() {
   const client = new Opik({
-    apiKey: process.env.OPIK_API_KEY,
-    apiUrl: process.env.OPIK_URL_OVERRIDE,
+    apiKey: opikApiKey,
+    apiUrl: opikApiUrl,
     projectName: opikProjectName,
     workspaceName: opikWorkspaceName,
   });
@@ -268,6 +293,19 @@ function serializedContains(value, token) {
     return false;
   }
   return JSON.stringify(value).includes(token);
+}
+
+async function readJsonIfExists(file) {
+  try {
+    const raw = await fs.readFile(file, "utf8");
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function trimOrUndefined(value) {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
 }
 
 async function runCommand(args, options) {

--- a/scripts/live-e2e.mjs
+++ b/scripts/live-e2e.mjs
@@ -11,24 +11,54 @@ import { Opik } from "opik";
 const ROOT_DIR = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const hostHomeDir = process.env.HOME ?? "";
 const hostOpenClawConfigPath = path.join(hostHomeDir, ".openclaw", "openclaw.json");
-const hostOpenClawConfig = await readJsonIfExists(hostOpenClawConfigPath);
-const hostOpikPluginConfig = hostOpenClawConfig?.plugins?.entries?.["opik-openclaw"]?.config;
+const useHostOpikConfig = process.env.OPENCLAW_LIVE_USE_HOST_OPIK_CONFIG !== "0";
+const hostOpenClawConfig = useHostOpikConfig ? await readJsonIfExists(hostOpenClawConfigPath) : null;
+const hostOpikPluginConfig = hostOpenClawConfig?.plugins?.entries?.["opik-openclaw"]?.config ?? null;
 
 const openAiApiKey = process.env.OPENAI_API_KEY?.trim();
-const opikApiKey = process.env.OPIK_API_KEY?.trim() ?? trimOrUndefined(hostOpikPluginConfig?.apiKey);
-const opikApiUrl =
-  process.env.OPIK_URL_OVERRIDE?.trim() ?? trimOrUndefined(hostOpikPluginConfig?.apiUrl);
+const opikApiKeyResolution = resolveConfigValue({
+  envKey: "OPIK_API_KEY",
+  envValue: process.env.OPIK_API_KEY,
+  fallbackValue: trimOrUndefined(hostOpikPluginConfig?.apiKey),
+  fallbackSource: hostOpenClawConfigPath,
+});
+const opikApiUrlResolution = resolveConfigValue({
+  envKey: "OPIK_URL_OVERRIDE",
+  envValue: process.env.OPIK_URL_OVERRIDE,
+  fallbackValue: trimOrUndefined(hostOpikPluginConfig?.apiUrl),
+  fallbackSource: hostOpenClawConfigPath,
+});
+const opikProjectResolution = resolveConfigValue({
+  envKey: "OPIK_PROJECT_NAME",
+  envValue: process.env.OPIK_PROJECT_NAME,
+  fallbackValue: trimOrUndefined(hostOpikPluginConfig?.projectName),
+  fallbackSource: hostOpenClawConfigPath,
+});
+const opikWorkspaceResolution = resolveConfigValue({
+  envKey: "OPIK_WORKSPACE",
+  envValue: process.env.OPIK_WORKSPACE,
+  fallbackValue: trimOrUndefined(hostOpikPluginConfig?.workspaceName),
+  fallbackSource: hostOpenClawConfigPath,
+});
+const opikApiKey = opikApiKeyResolution.value;
+const opikApiUrl = opikApiUrlResolution.value;
 
 const missingRequirements = [];
 if (!openAiApiKey) {
   missingRequirements.push("OPENAI_API_KEY");
 }
 if (!opikApiKey) {
-  missingRequirements.push("OPIK_API_KEY or ~/.openclaw/openclaw.json plugins.entries.opik-openclaw.config.apiKey");
+  missingRequirements.push(
+    useHostOpikConfig
+      ? "OPIK_API_KEY or ~/.openclaw/openclaw.json plugins.entries.opik-openclaw.config.apiKey"
+      : "OPIK_API_KEY",
+  );
 }
 if (!opikApiUrl) {
   missingRequirements.push(
-    "OPIK_URL_OVERRIDE or ~/.openclaw/openclaw.json plugins.entries.opik-openclaw.config.apiUrl",
+    useHostOpikConfig
+      ? "OPIK_URL_OVERRIDE or ~/.openclaw/openclaw.json plugins.entries.opik-openclaw.config.apiUrl"
+      : "OPIK_URL_OVERRIDE",
   );
 }
 if (missingRequirements.length > 0) {
@@ -51,14 +81,8 @@ const spansPath = path.join(artifactDir, "opik-spans.json");
 
 const gatewayPort = Number.parseInt(process.env.OPENCLAW_LIVE_GATEWAY_PORT ?? "18789", 10);
 const gatewayToken = process.env.OPENCLAW_GATEWAY_TOKEN?.trim() || `live-${randomUUID()}`;
-const opikProjectName =
-  process.env.OPIK_PROJECT_NAME?.trim() ??
-  trimOrUndefined(hostOpikPluginConfig?.projectName) ??
-  "openclaw";
-const opikWorkspaceName =
-  process.env.OPIK_WORKSPACE?.trim() ??
-  trimOrUndefined(hostOpikPluginConfig?.workspaceName) ??
-  "default";
+const opikProjectName = opikProjectResolution.value ?? "openclaw";
+const opikWorkspaceName = opikWorkspaceResolution.value ?? "default";
 const liveModel = process.env.OPENCLAW_LIVE_MODEL?.trim() || "gpt-4o-mini";
 const requestedOpenClawVersion = process.env.OPENCLAW_LIVE_OPENCLAW_VERSION?.trim() || "2026.4.15";
 const promptToken = `token-${randomUUID().slice(0, 8)}`;
@@ -82,6 +106,9 @@ await writeOpenClawConfig({ enablePlugin: false });
 let gatewayProcess;
 
 try {
+  console.log(
+    `[live-e2e] config sources: opikApiKey=${opikApiKeyResolution.source}, opikApiUrl=${opikApiUrlResolution.source}, project=${opikProjectResolution.source}, workspace=${opikWorkspaceResolution.source}`,
+  );
   await runCommand(["plugins", "install", pluginTarballPath], {
     env: openclawEnv,
     name: "openclaw plugins install",
@@ -293,6 +320,17 @@ function serializedContains(value, token) {
     return false;
   }
   return JSON.stringify(value).includes(token);
+}
+
+function resolveConfigValue(params) {
+  const envValue = trimOrUndefined(params.envValue);
+  if (envValue) {
+    return { value: envValue, source: `env:${params.envKey}` };
+  }
+  if (params.fallbackValue) {
+    return { value: params.fallbackValue, source: params.fallbackSource };
+  }
+  return { value: undefined, source: "unset" };
 }
 
 async function readJsonIfExists(file) {


### PR DESCRIPTION
## Summary
- add `scripts/live-e2e.mjs` to pack the current plugin, install it into an isolated OpenClaw home, run a real gateway turn, and query Opik back for the exported trace/span
- add `npm run test:live` for local live validation
- make the harness local-first by reusing `~/.openclaw/openclaw.json -> plugins.entries.opik-openclaw.config` for Opik credentials/settings when env vars are not set
- document the local harness and remove the earlier CI-secret angle from this PR

## Validation
- `npm test`
- `npm run typecheck`
- `npm run test:live`

## Notes
- this is intentionally a local harness, not a required CI lane
- it still needs `OPENAI_API_KEY` in env for the real model call
- local run passed against the existing Opik plugin config in `~/.openclaw/openclaw.json`
