### PR TITLE
fix(tracing): keep tool spans nested under llm attempts

### DIFF
--- a/scripts/live-e2e.mjs
+++ b/scripts/live-e2e.mjs
@@ -40,8 +40,11 @@ const opikWorkspaceResolution = resolveConfigValue({
   fallbackValue: trimOrUndefined(hostOpikPluginConfig?.workspaceName),
   fallbackSource: hostOpenClawConfigPath,
 });
+
 const opikApiKey = opikApiKeyResolution.value;
 const opikApiUrl = opikApiUrlResolution.value;
+const opikProjectName = opikProjectResolution.value ?? "openclaw";
+const opikWorkspaceName = opikWorkspaceResolution.value ?? "default";
 
 const missingRequirements = [];
 if (!openAiApiKey) {
@@ -69,25 +72,94 @@ if (missingRequirements.length > 0) {
   process.exit(1);
 }
 
+const scenarioDefinitions = [
+  {
+    id: "basic-response",
+    minSpanCount: 1,
+    buildPrompt: (token) => `Reply with the single word pong. Preserve token ${token}.`,
+    assertAgentOutput(output) {
+      if (!output.toLowerCase().includes("pong")) {
+        throw new Error("agent output did not contain the expected pong response");
+      }
+    },
+    assertExport({ traces, spans }) {
+      if (traces.length !== 1) {
+        throw new Error(`expected exactly 1 matching trace, got ${traces.length}`);
+      }
+      if (spans.length < 1) {
+        throw new Error(`expected at least 1 matching span, got ${spans.length}`);
+      }
+    },
+  },
+  {
+    id: "tool-exec",
+    minSpanCount: 2,
+    buildPrompt: (token) =>
+      `Use the exec tool exactly once to run the shell command printf '${token}'. ` +
+      `After reading the command output, reply with only ${token}. Do not guess and do not skip the tool.`,
+    assertAgentOutput(output, token) {
+      if (!output.includes(token)) {
+        throw new Error("agent output did not contain the expected tool token");
+      }
+    },
+    assertExport({ traces, spans }) {
+      if (traces.length !== 1) {
+        throw new Error(`expected exactly 1 matching trace, got ${traces.length}`);
+      }
+      const [trace] = traces;
+      if (trace.hasToolSpans !== true) {
+        throw new Error("matching trace did not report tool spans");
+      }
+      if ((trace.spanCount ?? 0) < 2) {
+        throw new Error(`expected at least 2 spans on the matching trace, got ${trace.spanCount}`);
+      }
+
+      const llmSpans = spans.filter((span) => span.type === "llm");
+      const toolSpans = spans.filter((span) => span.type === "tool");
+      if (llmSpans.length < 1) {
+        throw new Error("no llm spans were returned for the tool scenario");
+      }
+      if (toolSpans.length < 1) {
+        throw new Error("no tool spans were returned for the tool scenario");
+      }
+
+      const llmSpanIds = new Set(llmSpans.map((span) => span.id).filter(Boolean));
+      const hasNestedToolSpan = toolSpans.some(
+        (span) => typeof span.parentSpanId === "string" && llmSpanIds.has(span.parentSpanId),
+      );
+      if (!hasNestedToolSpan) {
+        throw new Error("no tool span was parented to a matching llm span");
+      }
+    },
+  },
+];
+
+const requestedScenarioIds = parseScenarioIds(process.env.OPENCLAW_LIVE_SCENARIOS);
+const scenarios =
+  requestedScenarioIds.length > 0
+    ? scenarioDefinitions.filter((scenario) => requestedScenarioIds.includes(scenario.id))
+    : scenarioDefinitions;
+
+if (scenarios.length === 0) {
+  throw new Error(
+    requestedScenarioIds.length > 0
+      ? `OPENCLAW_LIVE_SCENARIOS did not match any known scenarios: ${requestedScenarioIds.join(", ")}`
+      : "no live scenarios were selected",
+  );
+}
+
 const runId = `live-e2e-${Date.now()}-${randomUUID().slice(0, 8)}`;
 const artifactDir = path.join(ROOT_DIR, ".artifacts", "live-e2e", runId);
 const homeDir = path.join(artifactDir, "home");
 const openclawDir = path.join(homeDir, ".openclaw");
 const configPath = path.join(openclawDir, "openclaw.json");
 const gatewayLogPath = path.join(artifactDir, "gateway.log");
-const agentOutputPath = path.join(artifactDir, "agent-output.log");
-const tracesPath = path.join(artifactDir, "opik-traces.json");
-const spansPath = path.join(artifactDir, "opik-spans.json");
+const resultsPath = path.join(artifactDir, "results.json");
 
 const gatewayPort = Number.parseInt(process.env.OPENCLAW_LIVE_GATEWAY_PORT ?? "18789", 10);
 const gatewayToken = process.env.OPENCLAW_GATEWAY_TOKEN?.trim() || `live-${randomUUID()}`;
-const opikProjectName = opikProjectResolution.value ?? "openclaw";
-const opikWorkspaceName = opikWorkspaceResolution.value ?? "default";
 const liveModel = process.env.OPENCLAW_LIVE_MODEL?.trim() || "gpt-4o-mini";
 const requestedOpenClawVersion = process.env.OPENCLAW_LIVE_OPENCLAW_VERSION?.trim() || "2026.4.15";
-const promptToken = `token-${randomUUID().slice(0, 8)}`;
-const agentMessage = `Reply with the single word pong. Preserve token ${promptToken}.`;
-let opikSearchStartTime = new Date().toISOString();
 
 const openclawInvocation = resolveOpenClawInvocation(requestedOpenClawVersion);
 const openclawEnv = {
@@ -107,8 +179,15 @@ let gatewayProcess;
 
 try {
   console.log(
-    `[live-e2e] config sources: opikApiKey=${opikApiKeyResolution.source}, opikApiUrl=${opikApiUrlResolution.source}, project=${opikProjectResolution.source}, workspace=${opikWorkspaceResolution.source}`,
+    `[live-e2e] config sources: opikApiKey=${opikApiKeyResolution.source}, ` +
+      `opikApiUrl=${opikApiUrlResolution.source}, project=${opikProjectResolution.source}, ` +
+      `workspace=${opikWorkspaceResolution.source}`,
   );
+  console.log(
+    `[live-e2e] scenarios: ${scenarios.map((scenario) => scenario.id).join(", ")} ` +
+      `openclaw=${openclawInvocation.command}${openclawInvocation.baseArgs.length > 0 ? ` ${openclawInvocation.baseArgs.join(" ")}` : ""}`,
+  );
+
   await runCommand(["plugins", "install", pluginTarballPath], {
     env: openclawEnv,
     name: "openclaw plugins install",
@@ -118,30 +197,16 @@ try {
   gatewayProcess = startDetachedProcess(["gateway", "run"], gatewayLogPath);
   await waitForGateway();
 
-  opikSearchStartTime = new Date().toISOString();
-  const agentRun = await runCommand(
-    ["agent", "--agent", "main", "--message", agentMessage],
-    {
-      env: openclawEnv,
-      name: "openclaw agent",
-      captureOutput: true,
-    },
-  );
-  await fs.writeFile(agentOutputPath, agentRun.output, "utf8");
-
-  if (agentRun.output.includes("falling back to embedded")) {
-    throw new Error("gateway turn fell back to embedded mode");
-  }
-  if (!agentRun.output.toLowerCase().includes("pong")) {
-    throw new Error("agent output did not contain the expected pong response");
+  const results = [];
+  for (const scenario of scenarios) {
+    const result = await runScenario(scenario);
+    results.push(result);
   }
 
-  const { traces, spans } = await verifyOpikExport();
-  await fs.writeFile(tracesPath, JSON.stringify(traces, null, 2), "utf8");
-  await fs.writeFile(spansPath, JSON.stringify(spans, null, 2), "utf8");
+  await fs.writeFile(resultsPath, JSON.stringify(results, null, 2), "utf8");
 
   console.log(
-    `[live-e2e] PASS runId=${runId} traces=${traces.length} spans=${spans.length} artifacts=${artifactDir}`,
+    `[live-e2e] PASS runId=${runId} scenarios=${results.length} artifacts=${artifactDir}`,
   );
 } catch (error) {
   console.error(`[live-e2e] FAIL: ${formatError(error)}`);
@@ -149,6 +214,68 @@ try {
   process.exitCode = 1;
 } finally {
   await stopGateway(gatewayProcess);
+}
+
+async function runScenario(scenario) {
+  const scenarioDir = path.join(artifactDir, scenario.id);
+  const agentOutputPath = path.join(scenarioDir, "agent-output.log");
+  const tracesPath = path.join(scenarioDir, "opik-traces.json");
+  const spansPath = path.join(scenarioDir, "opik-spans.json");
+  const tokenPrefix = scenario.id === "tool-exec" ? "tool-token" : "token";
+  const promptToken = `${tokenPrefix}-${randomUUID().slice(0, 8)}`;
+  const agentMessage = scenario.buildPrompt(promptToken);
+
+  await fs.mkdir(scenarioDir, { recursive: true });
+
+  console.log(`[live-e2e] scenario start: ${scenario.id}`);
+  const opikSearchStartTime = new Date().toISOString();
+  const agentRun = await runCommand(["agent", "--agent", "main", "--message", agentMessage], {
+    env: openclawEnv,
+    name: `openclaw agent (${scenario.id})`,
+    captureOutput: true,
+  });
+  await fs.writeFile(agentOutputPath, agentRun.output, "utf8");
+
+  if (agentRun.output.includes("falling back to embedded")) {
+    throw new Error(`gateway turn fell back to embedded mode during ${scenario.id}`);
+  }
+  scenario.assertAgentOutput(agentRun.output, promptToken);
+
+  const { traces, spans } = await verifyOpikExport({
+    promptToken,
+    startedAt: opikSearchStartTime,
+    minSpanCount: scenario.minSpanCount,
+  });
+
+  await fs.writeFile(tracesPath, JSON.stringify(traces, null, 2), "utf8");
+  await fs.writeFile(spansPath, JSON.stringify(spans, null, 2), "utf8");
+
+  scenario.assertExport({ traces, spans, promptToken });
+
+  const traceSummary = traces.map((trace) => ({
+    id: trace.id,
+    spanCount: trace.spanCount,
+    llmSpanCount: trace.llmSpanCount,
+    hasToolSpans: trace.hasToolSpans,
+  }));
+  const spanSummary = spans.map((span) => ({
+    id: span.id,
+    parentSpanId: span.parentSpanId,
+    name: span.name,
+    type: span.type,
+    traceId: span.traceId,
+  }));
+
+  console.log(
+    `[live-e2e] scenario pass: ${scenario.id} traces=${traces.length} spans=${spans.length}`,
+  );
+
+  return {
+    scenario: scenario.id,
+    promptToken,
+    traces: traceSummary,
+    spans: spanSummary,
+  };
 }
 
 async function packPlugin() {
@@ -268,7 +395,7 @@ async function stopGateway(gateway) {
   }
 }
 
-async function verifyOpikExport() {
+async function verifyOpikExport(params) {
   const client = new Opik({
     apiKey: opikApiKey,
     apiUrl: opikApiUrl,
@@ -276,7 +403,7 @@ async function verifyOpikExport() {
     workspaceName: opikWorkspaceName,
   });
 
-  const startedAtFilter = escapeOqlString(opikSearchStartTime);
+  const startedAtFilter = escapeOqlString(params.startedAt);
   const traceFilter = `metadata.created_from = "openclaw" AND start_time >= "${startedAtFilter}"`;
 
   const traces = await client.searchTraces({
@@ -286,8 +413,12 @@ async function verifyOpikExport() {
     waitForTimeout: 90,
     maxResults: 20,
   });
-  const matchingTrace = traces.find((trace) => serializedContains(trace.input, promptToken));
-  if (!matchingTrace) {
+  const matchingTraces = traces.filter(
+    (trace) =>
+      serializedContains(trace.input, params.promptToken) ||
+      serializedContains(trace.output, params.promptToken),
+  );
+  if (matchingTraces.length < 1) {
     throw new Error(`no live Opik traces matched filter: ${traceFilter}`);
   }
 
@@ -295,20 +426,24 @@ async function verifyOpikExport() {
   const spans = await client.searchSpans({
     projectName: opikProjectName,
     filterString: spanFilter,
-    waitForAtLeast: 1,
+    waitForAtLeast: params.minSpanCount,
     waitForTimeout: 90,
-    maxResults: 30,
+    maxResults: 50,
   });
+  const traceIds = new Set(matchingTraces.map((trace) => trace.id).filter(Boolean));
   const matchingSpans = spans.filter(
     (span) =>
-      (matchingTrace.id && span.traceId === matchingTrace.id) ||
-      serializedContains(span.input, promptToken),
+      traceIds.has(span.traceId) ||
+      serializedContains(span.input, params.promptToken) ||
+      serializedContains(span.output, params.promptToken),
   );
-  if (matchingSpans.length < 1) {
-    throw new Error(`no live Opik spans matched filter: ${spanFilter}`);
+  if (matchingSpans.length < params.minSpanCount) {
+    throw new Error(
+      `expected at least ${params.minSpanCount} live Opik spans, got ${matchingSpans.length}`,
+    );
   }
 
-  return { traces: [matchingTrace], spans: matchingSpans };
+  return { traces: matchingTraces, spans: matchingSpans };
 }
 
 function escapeOqlString(value) {
@@ -331,6 +466,16 @@ function resolveConfigValue(params) {
     return { value: params.fallbackValue, source: params.fallbackSource };
   }
   return { value: undefined, source: "unset" };
+}
+
+function parseScenarioIds(rawValue) {
+  if (typeof rawValue !== "string" || rawValue.trim().length === 0) {
+    return [];
+  }
+  return rawValue
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
 }
 
 async function readJsonIfExists(file) {

--- a/src/service.test.ts
+++ b/src/service.test.ts
@@ -612,9 +612,11 @@ describe("opik service", () => {
 
     test("closes existing trace for same sessionKey before creating new one", async () => {
       const { api, hooks } = createApi();
-      const firstTrace = opikState.createMockTrace();
-      const secondTrace = opikState.createMockTrace();
-      mockTraceFn.mockReturnValueOnce(firstTrace).mockReturnValueOnce(secondTrace);
+      const mockTrace = opikState.createMockTrace();
+      const firstLlmSpan = opikState.createMockSpan();
+      const secondLlmSpan = opikState.createMockSpan();
+      mockTrace.span.mockReturnValueOnce(firstLlmSpan).mockReturnValueOnce(secondLlmSpan);
+      mockTraceFn.mockReturnValue(mockTrace);
 
       const service = createOpikService(api as any);
       await service.start(createServiceContext() as any);
@@ -622,8 +624,9 @@ describe("opik service", () => {
       invokeHook(hooks, "llm_input", { model: "m1", provider: "p", prompt: "" }, agentCtx("s1"));
       invokeHook(hooks, "llm_input", { model: "m2", provider: "p", prompt: "" }, agentCtx("s1"));
 
-      expect(firstTrace.end).toHaveBeenCalled();
-      expect(mockTraceFn).toHaveBeenCalledTimes(2);
+      expect(mockTrace.end).not.toHaveBeenCalled();
+      expect(mockTraceFn).toHaveBeenCalledTimes(1);
+      expect(mockTrace.span).toHaveBeenCalledTimes(2);
     });
 
     test("no-ops when sessionKey is missing", async () => {
@@ -846,9 +849,13 @@ describe("opik service", () => {
   // 4. before_tool_call hook
   // =========================================================================
   describe("before_tool_call hook", () => {
-    test("creates tool span on active trace with correct params", async () => {
+    test("creates tool span under the active llm span with correct params", async () => {
       const { api, hooks } = createApi();
       const mockTrace = opikState.createMockTrace();
+      const mockLlmSpan = opikState.createMockSpan();
+      const mockToolSpan = opikState.createMockSpan();
+      mockTrace.span.mockReturnValueOnce(mockLlmSpan);
+      mockLlmSpan.span.mockReturnValueOnce(mockToolSpan);
       mockTraceFn.mockReturnValue(mockTrace);
 
       const service = createOpikService(api as any);
@@ -865,7 +872,7 @@ describe("opik service", () => {
         toolCtx("s1"),
       );
 
-      expect(mockTrace.span).toHaveBeenCalledWith(
+      expect(mockLlmSpan.span).toHaveBeenCalledWith(
         expect.objectContaining({
           name: "web_search",
           type: "tool",
@@ -899,7 +906,8 @@ describe("opik service", () => {
       const mockTrace = opikState.createMockTrace();
       const mockLlmSpan = opikState.createMockSpan();
       const mockToolSpan = opikState.createMockSpan();
-      mockTrace.span.mockReturnValueOnce(mockLlmSpan).mockReturnValueOnce(mockToolSpan);
+      mockTrace.span.mockReturnValueOnce(mockLlmSpan);
+      mockLlmSpan.span.mockReturnValueOnce(mockToolSpan);
       mockTraceFn.mockReturnValue(mockTrace);
 
       const service = createOpikService(api as any);
@@ -918,8 +926,7 @@ describe("opik service", () => {
         toolCtx("s1", { sessionId: "ephemeral-1", agentId: "agent-7" }),
       );
 
-      expect(mockTrace.span).toHaveBeenNthCalledWith(
-        2,
+      expect(mockLlmSpan.span).toHaveBeenCalledWith(
         expect.objectContaining({
           name: "web_search",
           type: "tool",
@@ -945,7 +952,8 @@ describe("opik service", () => {
       const mockTrace = opikState.createMockTrace();
       // First span call is for LLM, second is for tool
       const mockLlmSpan = opikState.createMockSpan();
-      mockTrace.span.mockReturnValueOnce(mockLlmSpan).mockReturnValueOnce(mockToolSpan);
+      mockTrace.span.mockReturnValueOnce(mockLlmSpan);
+      mockLlmSpan.span.mockReturnValueOnce(mockToolSpan);
       mockTraceFn.mockReturnValue(mockTrace);
 
       const service = createOpikService(api as any);
@@ -972,7 +980,8 @@ describe("opik service", () => {
       const mockToolSpan = opikState.createMockSpan();
       const mockTrace = opikState.createMockTrace();
       const mockLlmSpan = opikState.createMockSpan();
-      mockTrace.span.mockReturnValueOnce(mockLlmSpan).mockReturnValueOnce(mockToolSpan);
+      mockTrace.span.mockReturnValueOnce(mockLlmSpan);
+      mockLlmSpan.span.mockReturnValueOnce(mockToolSpan);
       mockTraceFn.mockReturnValue(mockTrace);
 
       const service = createOpikService(api as any);
@@ -1008,7 +1017,8 @@ describe("opik service", () => {
       const mockToolSpan = opikState.createMockSpan();
       const mockTrace = opikState.createMockTrace();
       const mockLlmSpan = opikState.createMockSpan();
-      mockTrace.span.mockReturnValueOnce(mockLlmSpan).mockReturnValueOnce(mockToolSpan);
+      mockTrace.span.mockReturnValueOnce(mockLlmSpan);
+      mockLlmSpan.span.mockReturnValueOnce(mockToolSpan);
       mockTraceFn.mockReturnValue(mockTrace);
 
       const service = createOpikService(api as any);
@@ -1037,7 +1047,8 @@ describe("opik service", () => {
       const mockToolSpan = opikState.createMockSpan();
       const mockTrace = opikState.createMockTrace();
       const mockLlmSpan = opikState.createMockSpan();
-      mockTrace.span.mockReturnValueOnce(mockLlmSpan).mockReturnValueOnce(mockToolSpan);
+      mockTrace.span.mockReturnValueOnce(mockLlmSpan);
+      mockLlmSpan.span.mockReturnValueOnce(mockToolSpan);
       mockTraceFn.mockReturnValue(mockTrace);
 
       const service = createOpikService(api as any);
@@ -1080,7 +1091,8 @@ describe("opik service", () => {
       const mockToolSpan = opikState.createMockSpan();
       const mockTrace = opikState.createMockTrace();
       const mockLlmSpan = opikState.createMockSpan();
-      mockTrace.span.mockReturnValueOnce(mockLlmSpan).mockReturnValueOnce(mockToolSpan);
+      mockTrace.span.mockReturnValueOnce(mockLlmSpan);
+      mockLlmSpan.span.mockReturnValueOnce(mockToolSpan);
       mockTraceFn.mockReturnValue(mockTrace);
 
       const service = createOpikService(api as any);
@@ -1106,7 +1118,8 @@ describe("opik service", () => {
       const mockToolSpan = opikState.createMockSpan();
       const mockTrace = opikState.createMockTrace();
       const mockLlmSpan = opikState.createMockSpan();
-      mockTrace.span.mockReturnValueOnce(mockLlmSpan).mockReturnValueOnce(mockToolSpan);
+      mockTrace.span.mockReturnValueOnce(mockLlmSpan);
+      mockLlmSpan.span.mockReturnValueOnce(mockToolSpan);
       mockTraceFn.mockReturnValue(mockTrace);
 
       const service = createOpikService(api as any);
@@ -1166,7 +1179,8 @@ describe("opik service", () => {
       const mockToolSpan = opikState.createMockSpan();
       const mockTrace = opikState.createMockTrace();
       const mockLlmSpan = opikState.createMockSpan();
-      mockTrace.span.mockReturnValueOnce(mockLlmSpan).mockReturnValueOnce(mockToolSpan);
+      mockTrace.span.mockReturnValueOnce(mockLlmSpan);
+      mockLlmSpan.span.mockReturnValueOnce(mockToolSpan);
       mockTraceFn.mockReturnValue(mockTrace);
 
       const service = createOpikService(api as any);
@@ -1200,10 +1214,8 @@ describe("opik service", () => {
       const mockToolSpanB = opikState.createMockSpan();
       const mockTrace = opikState.createMockTrace();
       const mockLlmSpan = opikState.createMockSpan();
-      mockTrace.span
-        .mockReturnValueOnce(mockLlmSpan)
-        .mockReturnValueOnce(mockToolSpanA)
-        .mockReturnValueOnce(mockToolSpanB);
+      mockTrace.span.mockReturnValueOnce(mockLlmSpan);
+      mockLlmSpan.span.mockReturnValueOnce(mockToolSpanA).mockReturnValueOnce(mockToolSpanB);
       mockTraceFn.mockReturnValue(mockTrace);
 
       const service = createOpikService(api as any);
@@ -1371,8 +1383,10 @@ describe("opik service", () => {
       const llmSpanB = opikState.createMockSpan();
       const toolSpanB = opikState.createMockSpan();
 
-      traceA.span.mockReturnValueOnce(llmSpanA).mockReturnValueOnce(toolSpanA);
-      traceB.span.mockReturnValueOnce(llmSpanB).mockReturnValueOnce(toolSpanB);
+      traceA.span.mockReturnValueOnce(llmSpanA);
+      llmSpanA.span.mockReturnValueOnce(toolSpanA);
+      traceB.span.mockReturnValueOnce(llmSpanB);
+      llmSpanB.span.mockReturnValueOnce(toolSpanB);
       mockTraceFn.mockReturnValueOnce(traceA).mockReturnValueOnce(traceB);
 
       const service = createOpikService(api as any);
@@ -1804,7 +1818,8 @@ describe("opik service", () => {
       const mockToolSpan = opikState.createMockSpan();
       const mockLlmSpan = opikState.createMockSpan();
       const mockTrace = opikState.createMockTrace();
-      mockTrace.span.mockReturnValueOnce(mockLlmSpan).mockReturnValueOnce(mockToolSpan);
+      mockTrace.span.mockReturnValueOnce(mockLlmSpan);
+      mockLlmSpan.span.mockReturnValueOnce(mockToolSpan);
       mockTraceFn.mockReturnValue(mockTrace);
 
       const service = createOpikService(api as any);

--- a/src/service/hooks/llm.ts
+++ b/src/service/hooks/llm.ts
@@ -54,38 +54,42 @@ export function registerLlmHooks(deps: LlmHooksDeps): void {
     const trigger = resolveTrigger(agentCtxObj);
 
     const existing = deps.activeTraces.get(sessionKey);
-    if (existing) {
-      deps.closeActiveTrace(existing, `replace active trace sessionKey=${sessionKey}`);
-      deps.activeTraces.delete(sessionKey);
-      deps.forgetSessionCorrelation(sessionKey);
-    }
-
     let trace: Trace;
-    try {
-      const sanitizedTraceInput = sanitizeValueForOpik({
-        prompt: event.prompt,
-        systemPrompt: event.systemPrompt,
-        imagesCount: event.imagesCount,
-      }) as Record<string, unknown>;
-      trace = client.trace({
-        name: `${event.model} · ${channelId ?? "unknown"}`,
-        threadId: sessionKey,
-        input: sanitizedTraceInput,
-        metadata: {
-          created_from: OPIK_CREATED_FROM,
-          provider: normalizedProvider,
-          model: event.model,
-          sessionId: event.sessionId,
-          runId: event.runId,
-          agentId: agentCtx.agentId,
-          ...(channelId ? { channel: channelId, channelId } : {}),
-          ...(trigger ? { trigger } : {}),
-        },
-        tags: deps.getTags().length > 0 ? deps.getTags() : undefined,
-      });
-    } catch (err) {
-      deps.warn(`opik: trace creation failed (sessionKey=${sessionKey}): ${deps.formatError(err)}`);
-      return;
+    if (existing) {
+      trace = existing.trace;
+      if (existing.llmSpan) {
+        deps.safeSpanEnd(existing.llmSpan, `replace active llm span sessionKey=${sessionKey}`);
+        existing.llmSpan = null;
+      }
+    } else {
+      try {
+        const sanitizedTraceInput = sanitizeValueForOpik({
+          prompt: event.prompt,
+          systemPrompt: event.systemPrompt,
+          imagesCount: event.imagesCount,
+        }) as Record<string, unknown>;
+        trace = client.trace({
+          name: `${event.model} · ${channelId ?? "unknown"}`,
+          threadId: sessionKey,
+          input: sanitizedTraceInput,
+          metadata: {
+            created_from: OPIK_CREATED_FROM,
+            provider: normalizedProvider,
+            model: event.model,
+            sessionId: event.sessionId,
+            runId: event.runId,
+            agentId: agentCtx.agentId,
+            ...(channelId ? { channel: channelId, channelId } : {}),
+            ...(trigger ? { trigger } : {}),
+          },
+          tags: deps.getTags().length > 0 ? deps.getTags() : undefined,
+        });
+      } catch (err) {
+        deps.warn(
+          `opik: trace creation failed (sessionKey=${sessionKey}): ${deps.formatError(err)}`,
+        );
+        return;
+      }
     }
 
     let llmSpan: Span | null = null;
@@ -108,20 +112,30 @@ export function registerLlmHooks(deps: LlmHooksDeps): void {
     }
 
     const now = Date.now();
-    deps.activeTraces.set(sessionKey, {
-      trace,
-      llmSpan,
-      toolSpans: new Map(),
-      subagentSpans: new Map(),
-      startedAt: now,
-      lastActivityAt: now,
-      costMeta: {},
-      usage: {},
-      model: event.model,
-      provider: normalizedProvider,
-      channelId,
-      trigger,
-    });
+    if (existing) {
+      deps.applyContextMeta(existing, agentCtxObj);
+      existing.llmSpan = llmSpan;
+      existing.lastActivityAt = now;
+      existing.model = event.model;
+      existing.provider = normalizedProvider;
+      if (channelId) existing.channelId = channelId;
+      if (trigger) existing.trigger = trigger;
+    } else {
+      deps.activeTraces.set(sessionKey, {
+        trace,
+        llmSpan,
+        toolSpans: new Map(),
+        subagentSpans: new Map(),
+        startedAt: now,
+        lastActivityAt: now,
+        costMeta: {},
+        usage: {},
+        model: event.model,
+        provider: normalizedProvider,
+        channelId,
+        trigger,
+      });
+    }
 
     deps.scheduleMediaAttachmentUploads({
       entityType: "trace",

--- a/src/service/hooks/tool.ts
+++ b/src/service/hooks/tool.ts
@@ -40,6 +40,8 @@ export function registerToolHooks(deps: ToolHooksDeps): void {
     const container = deps.resolveSessionSpanContainer(sessionKey);
     if (!container) return;
     const active = container.active;
+    const toolParent =
+      container.sessionKey === sessionKey && active.llmSpan ? active.llmSpan : container.parent;
 
     active.lastActivityAt = Date.now();
 
@@ -58,7 +60,7 @@ export function registerToolHooks(deps: ToolHooksDeps): void {
 
     let toolSpan: Span;
     try {
-      toolSpan = container.parent.span({
+      toolSpan = toolParent.span({
         name: event.toolName,
         type: "tool",
         input: sanitizeValueForOpik(event.params) as any,


### PR DESCRIPTION
## Details
- keep a single Opik trace alive across repeated `llm_input` attempts for the same OpenClaw session
- create a new LLM span for each attempt instead of closing and replacing the whole trace
- parent normal-session tool spans under the active LLM span so tool execution stays attached to the model attempt that triggered it
- update tests that previously locked in the broken trace-per-attempt behavior

## Change checklist
- [x] User facing
- [ ] Documentation updated (if needed)
- [x] Tests added/updated (if needed)
- [ ] Breaking changes documented (if any)

## Issues
- Resolves #37

## Testing
- `npm run typecheck`
- `npm test`
- `npm run smoke`

## Documentation
- no docs change needed; this corrects emitted trace structure only
