### PR TITLE
chore: bump version to 0.2.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opik/opik-openclaw",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opik/opik-openclaw",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opik/opik-openclaw",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "license": "Apache-2.0",
   "description": "OpenClaw Opik exporter — sends LLM traces to Opik",
   "repository": {


### PR DESCRIPTION
## Details
- bump `@opik/opik-openclaw` from `0.2.10` to `0.2.11`
- release the tracing, live-e2e, ci, and dependency updates now on `main`

## Change checklist
- [x] User facing
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated (if needed)
- [ ] Breaking changes documented (if any)

## Issues
- Resolves #37

## Testing
- `npm run typecheck`
- `npm test`
- `npm run smoke`
- `npm pack --dry-run`

## Documentation
- no docs change needed for the version bump itself
