### PR TITLE
test(e2e): assert configured Opik project routing

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,6 +49,7 @@ jobs:
       E2E_LLM_RESULT_FILE: e2e-llm-result.json
       E2E_OPIK_JOURNAL_FILE: e2e-opik-journal.json
       E2E_LLM_JOURNAL_FILE: e2e-llm-journal.json
+      E2E_EXPECTED_OPIK_PROJECT: e2e-test
       OPENCLAW_GATEWAY_TOKEN: e2e-test-token
 
     steps:

--- a/scripts/check-e2e-result.mjs
+++ b/scripts/check-e2e-result.mjs
@@ -10,6 +10,7 @@ const RESULT_FILE = process.env.E2E_RESULT_FILE ?? "e2e-result.json";
 const LLM_RESULT_FILE = process.env.E2E_LLM_RESULT_FILE ?? "e2e-llm-result.json";
 const OPIK_JOURNAL_FILE = process.env.E2E_OPIK_JOURNAL_FILE ?? "e2e-opik-journal.json";
 const LLM_JOURNAL_FILE = process.env.E2E_LLM_JOURNAL_FILE ?? "e2e-llm-journal.json";
+const EXPECTED_OPIK_PROJECT = process.env.E2E_EXPECTED_OPIK_PROJECT?.trim() || null;
 
 function readJsonIfExists(file) {
   return fs.existsSync(file) ? JSON.parse(fs.readFileSync(file, "utf8")) : null;
@@ -23,7 +24,7 @@ function formatRecentRequests(label, journal) {
   const lines = recent.map((entry) => {
     const summary =
       entry.route === "traces-batch"
-        ? `traceCount=${entry.traceCount ?? 0} finalized=${entry.finalizedTraceCount ?? 0}`
+        ? `traceCount=${entry.traceCount ?? 0} finalized=${entry.finalizedTraceCount ?? 0} projects=${(entry.traceProjects ?? []).join(",") || "unknown"}`
         : entry.route === "spans-batch"
           ? `spanCount=${entry.spanCount ?? 0} finalized=${entry.finalizedSpanCount ?? 0}`
           : entry.route === "responses" || entry.route === "chat-completions"
@@ -89,6 +90,24 @@ if (llmGenerationRequests < 1) {
   );
 }
 
+if (EXPECTED_OPIK_PROJECT) {
+  const traceProjects = Array.isArray(result.traceProjects)
+    ? result.traceProjects.filter((value) => typeof value === "string" && value.length > 0)
+    : [];
+  if (!traceProjects.includes(EXPECTED_OPIK_PROJECT)) {
+    failures.push(
+      `Expected traces routed to project "${EXPECTED_OPIK_PROJECT}", got ${traceProjects.length > 0 ? traceProjects.join(", ") : "none"}`,
+    );
+  }
+
+  const unexpectedTraceProjects = traceProjects.filter((project) => project !== EXPECTED_OPIK_PROJECT);
+  if (unexpectedTraceProjects.length > 0) {
+    failures.push(
+      `Expected only project "${EXPECTED_OPIK_PROJECT}" in trace batches, got extra projects: ${unexpectedTraceProjects.join(", ")}`,
+    );
+  }
+}
+
 if (failures.length > 0) {
   console.error("[check-e2e] FAIL:");
   for (const f of failures) console.error("  •", f);
@@ -97,4 +116,6 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log("[check-e2e] PASS — traces, spans, patches, and mock LLM traffic were observed");
+console.log(
+  `[check-e2e] PASS — traces, spans, patches, mock LLM traffic, and project routing${EXPECTED_OPIK_PROJECT ? ` (${EXPECTED_OPIK_PROJECT})` : ""} were observed`,
+);

--- a/scripts/mock-opik-server.mjs
+++ b/scripts/mock-opik-server.mjs
@@ -25,8 +25,13 @@ const received = {
   endedSpans: 0,
   tracePatches: 0,
   spanPatches: 0,
+  traceProjects: new Set(),
   requests: [],
 };
+
+function resolveEntityProject(entity) {
+  return entity?.projectName ?? entity?.project_name ?? null;
+}
 
 function redactHeaders(headers) {
   const entries = Object.entries(headers ?? {});
@@ -43,6 +48,7 @@ function redactHeaders(headers) {
 function buildRequestSummary(method, url, body) {
   if (method === "POST" && url.includes("/traces/batch")) {
     const traces = body?.traces ?? [];
+    const traceProjects = [...new Set(traces.map(resolveEntityProject).filter(Boolean))];
     return {
       route: "traces-batch",
       traceCount: traces.length,
@@ -50,6 +56,7 @@ function buildRequestSummary(method, url, body) {
         (trace) => trace?.endTime !== undefined || trace?.end_time !== undefined,
       ).length,
       traceIds: traces.map((trace) => trace?.id).filter(Boolean).slice(0, 5),
+      traceProjects,
     };
   }
   if (method === "POST" && url.includes("/spans/batch")) {
@@ -93,6 +100,12 @@ function record(method, url, body, headers) {
     const traces = body?.traces ?? [];
     received.traces += traces.length;
     received.endedTraces += traces.filter((trace) => trace?.endTime !== undefined || trace?.end_time !== undefined).length;
+    for (const trace of traces) {
+      const projectName = resolveEntityProject(trace);
+      if (projectName) {
+        received.traceProjects.add(projectName);
+      }
+    }
   } else if (method === "POST" && url.includes("/spans/batch")) {
     const spans = body?.spans ?? [];
     received.spans += spans.length;
@@ -148,6 +161,7 @@ function writeResult() {
     endedSpans: received.endedSpans,
     tracePatches: received.tracePatches,
     spanPatches: received.spanPatches,
+    traceProjects: [...received.traceProjects].sort(),
     totalRequests: received.requests.length,
   };
   fs.writeFileSync(RESULT_FILE, JSON.stringify(summary, null, 2));


### PR DESCRIPTION
## Details
- investigate the reported `client.trace()` / `projectName` gap and confirm the current Opik SDK already inherits `projectName` from the client config
- harden the mock Opik e2e path so it records trace project names and fails if traces stop targeting the configured project
- wire the expected project into the GitHub Actions e2e workflow so the check is active in CI

## Change checklist
- [ ] User facing
- [ ] Documentation updated (if needed)
- [x] Tests added/updated (if needed)
- [ ] Breaking changes documented (if any)

## Issues
- Resolves #
- OPIK-

## Testing
- `npm run test`
- `npm run typecheck`
- validated `scripts/check-e2e-result.mjs` with the mock Opik server in two cases:
  - pass when traces are written to `e2e-test`
  - fail when traces are written to `Default Project`

## Documentation
- none
