### PR TITLE
fix(tracing): pass project name explicitly to llm traces

### DIFF
--- a/src/service.test.ts
+++ b/src/service.test.ts
@@ -470,6 +470,36 @@ describe("opik service", () => {
       );
     });
 
+    test("passes the configured project name when creating traces", async () => {
+      const { api, hooks } = createApi();
+      const service = createOpikService(api as any);
+      await service.start(
+        createServiceContext(true, {
+          enabled: true,
+          apiKey: "test-key",
+          projectName: "team-project",
+        }) as any,
+      );
+
+      invokeHook(
+        hooks,
+        "llm_input",
+        {
+          model: "gpt-4",
+          provider: "openai",
+          prompt: "Hello",
+          historyMessages: [],
+        },
+        agentCtx("session-1"),
+      );
+
+      expect(mockTraceFn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectName: "team-project",
+        }),
+      );
+    });
+
     test("normalizes openai-codex provider to openai on trace/span creation", async () => {
       const { api, hooks } = createApi();
       const mockTrace = opikState.createMockTrace();

--- a/src/service/hooks/llm.ts
+++ b/src/service/hooks/llm.ts
@@ -70,6 +70,7 @@ export function registerLlmHooks(deps: LlmHooksDeps): void {
         }) as Record<string, unknown>;
         trace = client.trace({
           name: `${event.model} · ${channelId ?? "unknown"}`,
+          projectName: deps.getProjectName(),
           threadId: sessionKey,
           input: sanitizedTraceInput,
           metadata: {


### PR DESCRIPTION
## Details
- pass `projectName` explicitly when `src/service/hooks/llm.ts` creates a new Opik trace
- add a unit test that proves the hook forwards the configured project name into `client.trace()`
- keep the change scoped to LLM trace creation so existing behavior stays untouched elsewhere

## Why
The SDK currently falls back to the client's configured project, but relying on that implicit behavior is brittle. Passing `projectName` explicitly makes the hook self-contained and removes any ambiguity about where LLM traces should land.

## Change checklist
- [ ] User facing
- [ ] Documentation updated (if needed)
- [x] Tests added/updated (if needed)
- [ ] Breaking changes documented (if any)

## Issues
- Resolves #
- OPIK-

## Testing
- `npm run test`
- `npm run typecheck`

## Documentation
- none
