### PR TITLE
refactor(tracing): avoid llm session context copies

### DIFF
--- a/src/service.test.ts
+++ b/src/service.test.ts
@@ -500,6 +500,34 @@ describe("opik service", () => {
       );
     });
 
+    test("prefers llm_input event.sessionId over ctx.sessionId when sessionKey is absent", async () => {
+      const { api, hooks } = createApi();
+      const service = createOpikService(api as any);
+      await service.start(createServiceContext() as any);
+
+      invokeHook(
+        hooks,
+        "llm_input",
+        {
+          model: "gpt-4",
+          provider: "openai",
+          prompt: "Hello",
+          sessionId: "event-session-id",
+          historyMessages: [],
+        },
+        agentCtx(undefined, { sessionId: "ctx-session-id" }),
+      );
+
+      expect(mockTraceFn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          threadId: "event-session-id",
+          metadata: expect.objectContaining({
+            sessionId: "event-session-id",
+          }),
+        }),
+      );
+    });
+
     test("normalizes openai-codex provider to openai on trace/span creation", async () => {
       const { api, hooks } = createApi();
       const mockTrace = opikState.createMockTrace();

--- a/src/service.ts
+++ b/src/service.ts
@@ -132,11 +132,14 @@ export function createOpikService(
     }
   }
 
-  function resolveSessionKey(ctx: Record<string, unknown>): string | undefined {
+  function resolveSessionKey(
+    ctx: Record<string, unknown>,
+    sessionIdOverride?: string,
+  ): string | undefined {
     const explicitSessionKey = asNonEmptyString(ctx.sessionKey);
     if (explicitSessionKey) return explicitSessionKey;
 
-    const sessionId = asNonEmptyString(ctx.sessionId);
+    const sessionId = sessionIdOverride ?? asNonEmptyString(ctx.sessionId);
     if (sessionId) return sessionId;
 
     const agentId = asNonEmptyString(ctx.agentId);

--- a/src/service/hooks/llm.ts
+++ b/src/service/hooks/llm.ts
@@ -21,7 +21,7 @@ type LlmHooksDeps = {
   closeActiveTrace: (active: ActiveTrace, reason: string) => void;
   forgetSessionCorrelation: (sessionKey: string) => void;
   applyContextMeta: (active: ActiveTrace, ctx: Record<string, unknown>) => void;
-  resolveSessionKey: (ctx: Record<string, unknown>) => string | undefined;
+  resolveSessionKey: (ctx: Record<string, unknown>, sessionIdOverride?: string) => string | undefined;
   safeSpanUpdate: (span: Span, payload: Record<string, unknown>, reason: string) => void;
   safeSpanEnd: (span: Span, reason: string) => void;
   scheduleMediaAttachmentUploads: (params: {
@@ -39,10 +39,7 @@ export function registerLlmHooks(deps: LlmHooksDeps): void {
   deps.api.on("llm_input", (event, agentCtx) => {
     const client = deps.getClient();
     const agentCtxObj = agentCtx as Record<string, unknown>;
-    const sessionKey = deps.resolveSessionKey({
-      ...agentCtxObj,
-      sessionId: asNonEmptyString(event.sessionId) ?? agentCtxObj.sessionId,
-    });
+    const sessionKey = deps.resolveSessionKey(agentCtxObj, asNonEmptyString(event.sessionId));
     if (!client) return;
     if (!sessionKey) {
       deps.warn("opik: llm_input missing sessionKey");


### PR DESCRIPTION
## Details
- teach `resolveSessionKey` to accept an optional `sessionId` override instead of requiring callers to allocate a merged context object
- update `llm_input` to pass the event `sessionId` directly while preserving the existing precedence rules
- add a regression test proving `llm_input` still prefers `event.sessionId` over `ctx.sessionId` when `sessionKey` is absent

## Change checklist
- [ ] User facing
- [ ] Documentation updated (if needed)
- [x] Tests added/updated (if needed)
- [ ] Breaking changes documented (if any)

## Issues
- Resolves #
- OPIK-

## Testing
- `npm run test`
- `npm run typecheck`
- `npm run test:live`

## Documentation
- none
