### PR TITLE
refactor(tracing): dedupe llm input sanitization

### DIFF
--- a/src/service.test.ts
+++ b/src/service.test.ts
@@ -594,6 +594,9 @@ describe("opik service", () => {
       expect(traceInput.systemPrompt).toBe("use media:<image-ref> for docs examples");
 
       const llmSpanInput = (mockTrace.span.mock.calls[0][0] as any).input;
+      expect(llmSpanInput.prompt).toBe("send media:<image-ref>");
+      expect(llmSpanInput.systemPrompt).toBe("use media:<image-ref> for docs examples");
+      expect(llmSpanInput.imagesCount).toBe(0);
       expect(llmSpanInput.historyMessages[0].content).toBe("example media:<image-ref>");
     });
 

--- a/src/service/hooks/llm.ts
+++ b/src/service/hooks/llm.ts
@@ -51,6 +51,11 @@ export function registerLlmHooks(deps: LlmHooksDeps): void {
     const trigger = resolveTrigger(agentCtxObj);
     const projectName = deps.getProjectName();
     const tags = deps.getTags();
+    const sanitizedSharedLlmInput = sanitizeValueForOpik({
+      prompt: event.prompt,
+      systemPrompt: event.systemPrompt,
+      imagesCount: event.imagesCount,
+    }) as Record<string, unknown>;
 
     const existing = deps.activeTraces.get(sessionKey);
     let trace: Trace;
@@ -62,16 +67,11 @@ export function registerLlmHooks(deps: LlmHooksDeps): void {
       }
     } else {
       try {
-        const sanitizedTraceInput = sanitizeValueForOpik({
-          prompt: event.prompt,
-          systemPrompt: event.systemPrompt,
-          imagesCount: event.imagesCount,
-        }) as Record<string, unknown>;
         trace = client.trace({
           name: `${event.model} · ${channelId ?? "unknown"}`,
           projectName,
           threadId: sessionKey,
-          input: sanitizedTraceInput,
+          input: sanitizedSharedLlmInput,
           metadata: {
             created_from: OPIK_CREATED_FROM,
             provider: normalizedProvider,
@@ -94,12 +94,13 @@ export function registerLlmHooks(deps: LlmHooksDeps): void {
 
     let llmSpan: Span | null = null;
     try {
-      const sanitizedLlmInput = sanitizeValueForOpik({
-        prompt: event.prompt,
-        systemPrompt: event.systemPrompt,
-        historyMessages: event.historyMessages,
-        imagesCount: event.imagesCount,
-      }) as Record<string, unknown>;
+      const sanitizedHistoryMessages = sanitizeValueForOpik(event.historyMessages);
+      const sanitizedLlmInput = {
+        ...sanitizedSharedLlmInput,
+        ...(sanitizedHistoryMessages === undefined
+          ? {}
+          : { historyMessages: sanitizedHistoryMessages }),
+      } as Record<string, unknown>;
       llmSpan = trace.span({
         name: event.model,
         type: "llm",


### PR DESCRIPTION
## Details
- sanitize the shared LLM trace/span input fields once per `llm_input` event instead of sanitizing the same prompt/systemPrompt/imagesCount payload twice
- sanitize `historyMessages` separately and compose the span payload from the already-sanitized shared fields
- extend the llm input regression test to assert the span sees the same sanitized shared fields as the trace

## Change checklist
- [ ] User facing
- [ ] Documentation updated (if needed)
- [x] Tests added/updated (if needed)
- [ ] Breaking changes documented (if any)

## Issues
- Resolves #
- OPIK-

## Testing
- `npm run test`
- `npm run typecheck`
- `npm run test:live`

## Documentation
- none
