### PR TITLE
Package OpenClaw runtime extension build output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,11 @@ on:
       - "package.json"
       - "package-lock.json"
       - "tsconfig.json"
+      - "tsconfig.build.json"
       - "index.ts"
       - "openclaw.plugin.json"
       - "src/**"
+      - "scripts/check-pack-payload.mjs"
   push:
     branches:
       - main
@@ -22,9 +24,11 @@ on:
       - "package.json"
       - "package-lock.json"
       - "tsconfig.json"
+      - "tsconfig.build.json"
       - "index.ts"
       - "openclaw.plugin.json"
       - "src/**"
+      - "scripts/check-pack-payload.mjs"
   workflow_dispatch:
 
 jobs:
@@ -48,6 +52,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Run build
+        run: npm run build
+
       - name: Run lint
         run: npm run lint
 
@@ -61,4 +68,4 @@ jobs:
         run: npm run smoke
 
       - name: Verify package payload
-        run: npm pack --dry-run
+        run: npm run pack:check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ on:
       - "index.ts"
       - "openclaw.plugin.json"
       - "src/**"
+      - "scripts/build.mjs"
       - "scripts/check-pack-payload.mjs"
   push:
     branches:
@@ -28,6 +29,7 @@ on:
       - "index.ts"
       - "openclaw.plugin.json"
       - "src/**"
+      - "scripts/build.mjs"
       - "scripts/check-pack-payload.mjs"
   workflow_dispatch:
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,6 +20,9 @@ on:
       - "src/**"
       - "scripts/**"
       - "package.json"
+      - "package-lock.json"
+      - "tsconfig.json"
+      - "tsconfig.build.json"
   pull_request:
     branches: [main]
     paths:
@@ -28,6 +31,9 @@ on:
       - "src/**"
       - "scripts/**"
       - "package.json"
+      - "package-lock.json"
+      - "tsconfig.json"
+      - "tsconfig.build.json"
   schedule:
     - cron: '0 6 * * *'  # daily at 6am UTC — catches new OpenClaw releases breaking the plugin
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,10 @@ jobs:
         if: steps.exists.outputs.already_published == 'false'
         run: npm ci
 
+      - name: Run build
+        if: steps.exists.outputs.already_published == 'false'
+        run: npm run build
+
       - name: Run lint
         if: steps.exists.outputs.already_published == 'false'
         run: npm run lint
@@ -85,7 +89,7 @@ jobs:
 
       - name: Verify package payload
         if: steps.exists.outputs.already_published == 'false'
-        run: npm pack --dry-run
+        run: npm run pack:check
 
       - name: Prepare trusted publishing auth
         if: steps.exists.outputs.already_published == 'false'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,11 +40,16 @@ cp .env.example .env
 Recommended local checks:
 
 ```bash
+npm run build
 npm run lint
 npm run typecheck
 npm run test
 npm run smoke
 ```
+
+Packaging changes should preserve the OpenClaw package contract: source metadata
+stays in `openclaw.extensions`, installed runtime code stays in
+`openclaw.runtimeExtensions`, and `npm run pack:check` must pass.
 
 ## Pull requests
 

--- a/README.md
+++ b/README.md
@@ -173,11 +173,20 @@ Prerequisites:
 
 ```bash
 npm ci
+npm run build
 npm run lint
 npm run typecheck
 npm run test
 npm run smoke
 ```
+
+### Packaging
+
+The package publishes built JavaScript for installed OpenClaw runtime loads while
+keeping TypeScript source metadata for development and older OpenClaw fallback
+loads. `openclaw.extensions` points at `./index.ts`; `openclaw.runtimeExtensions`
+points at `./dist/index.js`. `npm pack` and `npm publish` run `npm run build`
+through `prepack`, and `npm run pack:check` verifies the tarball contract.
 
 Optional live gateway E2E:
 
@@ -193,7 +202,7 @@ Notes:
 - set `OPENCLAW_LIVE_USE_HOST_OPIK_CONFIG=0` to disable reading host plugin config and require explicit env-only Opik settings
 - still requires `OPENAI_API_KEY` in env for the real model call
 - packs and installs the current plugin build into a fresh OpenClaw home
-- falls back to `npx openclaw@${OPENCLAW_LIVE_OPENCLAW_VERSION:-2026.4.15}` when `openclaw` is not already on your `PATH`
+- falls back to `npx openclaw@${OPENCLAW_LIVE_OPENCLAW_VERSION:-latest}` when `openclaw` is not already on your `PATH`
 - override the live model with `OPENCLAW_LIVE_MODEL` if `gpt-4o-mini` is not what you want to exercise
 
 ## Contributing

--- a/index.ts
+++ b/index.ts
@@ -1,12 +1,8 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
-import { disableLogger } from "opik";
-import { registerOpikCli } from "./src/configure.js";
+import { registerOpikCli } from "./src/cli.js";
 import { createOpikService, type OpikRuntimeService } from "./src/service.js";
 import { parseOpikPluginConfig } from "./src/types.js";
-
-// Suppress Opik SDK tslog console output
-disableLogger();
 
 const plugin = {
   id: "opik-openclaw",

--- a/package.json
+++ b/package.json
@@ -8,17 +8,21 @@
     "url": "https://github.com/comet-ml/opik-openclaw"
   },
   "type": "module",
+  "types": "./dist/index.d.ts",
   "engines": {
     "node": ">=22.12.0",
     "npm": ">=10"
   },
   "scripts": {
+    "build": "tsc -p tsconfig.build.json",
     "lint": "tsc --noEmit",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:e2e": "vitest run src/**/*.e2e.test.ts",
     "test:live": "node scripts/live-e2e.mjs",
-    "smoke": "vitest run src/plugin.smoke.test.ts"
+    "smoke": "vitest run src/plugin.smoke.test.ts",
+    "pack:check": "node scripts/check-pack-payload.mjs",
+    "prepack": "npm run build"
   },
   "dependencies": {
     "@clack/prompts": "^1.0.1",
@@ -35,7 +39,9 @@
     "vitest": "^4.0.18"
   },
   "files": [
+    "dist/**",
     "index.ts",
+    "src/cli.ts",
     "src/configure.ts",
     "src/service.ts",
     "src/service/constants.ts",
@@ -54,6 +60,17 @@
   "openclaw": {
     "extensions": [
       "./index.ts"
-    ]
+    ],
+    "runtimeExtensions": [
+      "./dist/index.js"
+    ],
+    "compat": {
+      "pluginApi": ">=2026.3.2",
+      "minGatewayVersion": "2026.3.2"
+    },
+    "build": {
+      "openclawVersion": "2026.3.2",
+      "pluginSdkVersion": "2026.3.2"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "npm": ">=10"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "node scripts/build.mjs",
     "lint": "tsc --noEmit",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+import { rmSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+
+rmSync("dist", { force: true, recursive: true });
+
+const tscCommand = process.platform === "win32" ? "tsc.cmd" : "tsc";
+const build = spawnSync(tscCommand, ["-p", "tsconfig.build.json"], {
+  cwd: process.cwd(),
+  stdio: "inherit",
+});
+
+if (build.status !== 0) {
+  process.exit(build.status ?? 1);
+}

--- a/scripts/check-pack-payload.mjs
+++ b/scripts/check-pack-payload.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+
+const pack = spawnSync("npm", ["pack", "--dry-run", "--json"], {
+  cwd: process.cwd(),
+  encoding: "utf8",
+  stdio: ["ignore", "pipe", "pipe"],
+});
+
+if (pack.status !== 0) {
+  process.stderr.write(pack.stdout);
+  process.stderr.write(pack.stderr);
+  process.exit(pack.status ?? 1);
+}
+
+let payload;
+try {
+  payload = JSON.parse(pack.stdout);
+} catch (error) {
+  console.error(`npm pack did not return JSON: ${String(error)}`);
+  process.stderr.write(pack.stdout);
+  process.exit(1);
+}
+
+const files = new Set(payload[0]?.files?.map((file) => file.path) ?? []);
+const requiredFiles = [
+  "package.json",
+  "openclaw.plugin.json",
+  "index.ts",
+  "src/cli.ts",
+  "dist/index.js",
+  "dist/index.d.ts",
+  "dist/src/cli.js",
+];
+const missingFiles = requiredFiles.filter((file) => !files.has(file));
+
+const packageJson = JSON.parse(fs.readFileSync("package.json", "utf8"));
+const expectedExtensions = ["./index.ts"];
+const expectedRuntimeExtensions = ["./dist/index.js"];
+const issues = [];
+
+function sameStringArray(actual, expected) {
+  return (
+    Array.isArray(actual) &&
+    actual.length === expected.length &&
+    actual.every((value, index) => value === expected[index])
+  );
+}
+
+function requireStringArray(name, actual, expected) {
+  if (!sameStringArray(actual, expected)) {
+    issues.push(`${name} must be ${JSON.stringify(expected)}`);
+  }
+}
+
+if (missingFiles.length > 0) {
+  issues.push(`missing packed files: ${missingFiles.join(", ")}`);
+}
+requireStringArray("openclaw.extensions", packageJson.openclaw?.extensions, expectedExtensions);
+requireStringArray(
+  "openclaw.runtimeExtensions",
+  packageJson.openclaw?.runtimeExtensions,
+  expectedRuntimeExtensions,
+);
+if (!packageJson.files?.includes("dist/**")) {
+  issues.push("package files must include dist/**");
+}
+
+if (issues.length > 0) {
+  console.error(`Package payload check failed:\n- ${issues.join("\n- ")}`);
+  process.exit(1);
+}
+
+console.log(
+  `Package payload OK: ${payload[0]?.entryCount ?? files.size} files, runtime ./dist/index.js`,
+);

--- a/scripts/check-pack-payload.mjs
+++ b/scripts/check-pack-payload.mjs
@@ -2,6 +2,7 @@
 
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import path from "node:path";
 
 const pack = spawnSync("npm", ["pack", "--dry-run", "--json"], {
   cwd: process.cwd(),
@@ -32,7 +33,6 @@ const requiredFiles = [
   "src/cli.ts",
   "dist/index.js",
   "dist/index.d.ts",
-  "dist/src/cli.js",
 ];
 const missingFiles = requiredFiles.filter((file) => !files.has(file));
 
@@ -40,6 +40,27 @@ const packageJson = JSON.parse(fs.readFileSync("package.json", "utf8"));
 const expectedExtensions = ["./index.ts"];
 const expectedRuntimeExtensions = ["./dist/index.js"];
 const issues = [];
+
+function listFilesRecursively(rootDir) {
+  if (!fs.existsSync(rootDir)) {
+    return [];
+  }
+
+  const files = [];
+  for (const entry of fs.readdirSync(rootDir, { withFileTypes: true })) {
+    const entryPath = path.join(rootDir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...listFilesRecursively(entryPath).map((file) => `${entry.name}/${file}`));
+      continue;
+    }
+
+    if (entry.isFile()) {
+      files.push(entry.name);
+    }
+  }
+
+  return files.sort();
+}
 
 function sameStringArray(actual, expected) {
   return (
@@ -58,6 +79,28 @@ function requireStringArray(name, actual, expected) {
 if (missingFiles.length > 0) {
   issues.push(`missing packed files: ${missingFiles.join(", ")}`);
 }
+
+const builtDistFiles = listFilesRecursively("dist");
+const packedDistFiles = [...files]
+  .filter((file) => file.startsWith("dist/"))
+  .map((file) => file.slice("dist/".length))
+  .sort();
+
+if (builtDistFiles.length === 0) {
+  issues.push("dist must contain built output before packing");
+} else if (JSON.stringify(packedDistFiles) !== JSON.stringify(builtDistFiles)) {
+  const missingPackedDistFiles = builtDistFiles.filter((file) => !packedDistFiles.includes(file));
+  const unexpectedPackedDistFiles = packedDistFiles.filter((file) => !builtDistFiles.includes(file));
+
+  if (missingPackedDistFiles.length > 0) {
+    issues.push(`packed dist is missing files: ${missingPackedDistFiles.join(", ")}`);
+  }
+
+  if (unexpectedPackedDistFiles.length > 0) {
+    issues.push(`packed dist has unexpected files: ${unexpectedPackedDistFiles.join(", ")}`);
+  }
+}
+
 requireStringArray("openclaw.extensions", packageJson.openclaw?.extensions, expectedExtensions);
 requireStringArray(
   "openclaw.runtimeExtensions",

--- a/scripts/live-e2e.mjs
+++ b/scripts/live-e2e.mjs
@@ -159,7 +159,7 @@ const resultsPath = path.join(artifactDir, "results.json");
 const gatewayPort = Number.parseInt(process.env.OPENCLAW_LIVE_GATEWAY_PORT ?? "18789", 10);
 const gatewayToken = process.env.OPENCLAW_GATEWAY_TOKEN?.trim() || `live-${randomUUID()}`;
 const liveModel = process.env.OPENCLAW_LIVE_MODEL?.trim() || "gpt-4o-mini";
-const requestedOpenClawVersion = process.env.OPENCLAW_LIVE_OPENCLAW_VERSION?.trim() || "2026.4.15";
+const requestedOpenClawVersion = process.env.OPENCLAW_LIVE_OPENCLAW_VERSION?.trim() || "latest";
 
 const openclawInvocation = resolveOpenClawInvocation(requestedOpenClawVersion);
 const openclawEnv = {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,41 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+
+type ConfigDeps = {
+  loadConfig: () => OpenClawConfig;
+  writeConfigFile: (cfg: OpenClawConfig) => Promise<void>;
+};
+
+type RegisterOpikCliParams = {
+  program: any;
+} & ConfigDeps;
+
+async function runConfigureLazy(deps: ConfigDeps): Promise<void> {
+  const { runOpikConfigure } = await import("./configure.js");
+  await runOpikConfigure(deps);
+}
+
+async function showStatusLazy(deps: ConfigDeps): Promise<void> {
+  const { showOpikStatus } = await import("./configure.js");
+  showOpikStatus(deps);
+}
+
+export function registerOpikCli(params: RegisterOpikCliParams): void {
+  const { program, loadConfig, writeConfigFile } = params;
+  const deps: ConfigDeps = { loadConfig, writeConfigFile };
+
+  const root = program.command("opik").description("Opik trace export integration");
+
+  root
+    .command("configure")
+    .description("Interactive setup for Opik trace export")
+    .action(async () => {
+      await runConfigureLazy(deps);
+    });
+
+  root
+    .command("status")
+    .description("Show current Opik configuration")
+    .action(async () => {
+      await showStatusLazy(deps);
+    });
+}

--- a/src/configure.test.ts
+++ b/src/configure.test.ts
@@ -3,10 +3,10 @@ import { describe, expect, test, vi } from "vitest";
 import {
   getOpikPluginEntry,
   getApiKeyHelpText,
-  registerOpikCli,
   setOpikPluginEntry,
   showOpikStatus,
 } from "./configure.js";
+import { registerOpikCli } from "./cli.js";
 
 describe("configure helpers", () => {
   test("setOpikPluginEntry writes plugins.entries.opik-openclaw", () => {
@@ -68,7 +68,6 @@ describe("configure helpers", () => {
 
 describe("opik status command", () => {
   test("reads plugin entry and masks api key", async () => {
-    const program = new Command();
     const loadConfig = () =>
       ({
         plugins: {
@@ -88,12 +87,6 @@ describe("opik status command", () => {
         },
       }) as any;
 
-    registerOpikCli({
-      program, // keep a smoke-level check that command registration still succeeds
-      loadConfig,
-      writeConfigFile: async () => undefined,
-    });
-
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
     showOpikStatus({
       loadConfig,
@@ -106,8 +99,10 @@ describe("opik status command", () => {
     expect(output).not.toContain("secret-key");
   });
 
-  test("status command is registered under openclaw opik", () => {
+  test("status command runs through registered lazy CLI action", async () => {
     const program = new Command();
+    program.exitOverride();
+
     registerOpikCli({
       program,
       loadConfig: () =>
@@ -130,8 +125,18 @@ describe("opik status command", () => {
         }) as any,
       writeConfigFile: async () => undefined,
     });
-    const opikCommand = program.commands.find((cmd) => cmd.name() === "opik");
-    expect(opikCommand).toBeDefined();
-    expect(opikCommand?.commands.map((cmd) => cmd.name())).toContain("status");
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    let output = "";
+    try {
+      await program.parseAsync(["node", "openclaw", "opik", "status"]);
+      output = logSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+    } finally {
+      logSpy.mockRestore();
+    }
+
+    expect(output).toContain("Enabled:    yes");
+    expect(output).toContain("API key:    ***");
+    expect(output).not.toContain("secret-key");
   });
 });

--- a/src/configure.ts
+++ b/src/configure.ts
@@ -7,10 +7,6 @@ type ConfigDeps = {
   writeConfigFile: (cfg: OpenClawConfig) => Promise<void>;
 };
 
-type RegisterOpikCliParams = {
-  program: any;
-} & ConfigDeps;
-
 /** Opik Cloud host (matches SDK's DEFAULT_HOST_URL). */
 const OPIK_CLOUD_HOST = "https://www.comet.com/";
 const OPIK_CLOUD_SIGNUP_URL = "https://www.comet.com/signup?from=llm&source=openclaw";
@@ -240,7 +236,7 @@ async function promptAndValidateUrl(placeholder: string): Promise<string> {
 // Interactive configure wizard (mirrors opik SDK getOrAskForProjectData)
 // ---------------------------------------------------------------------------
 
-async function runOpikConfigure(deps: ConfigDeps): Promise<void> {
+export async function runOpikConfigure(deps: ConfigDeps): Promise<void> {
   p.intro("Opik setup");
 
   // Step 1: Check if local Opik is already running (for hint in selector)
@@ -429,29 +425,4 @@ export function showOpikStatus(deps: ConfigDeps): void {
 
   console.log("Opik status:\n");
   console.log(lines.join("\n"));
-}
-
-// ---------------------------------------------------------------------------
-// CLI registration
-// ---------------------------------------------------------------------------
-
-export function registerOpikCli(params: RegisterOpikCliParams): void {
-  const { program, loadConfig, writeConfigFile } = params;
-  const deps: ConfigDeps = { loadConfig, writeConfigFile };
-
-  const root = program.command("opik").description("Opik trace export integration");
-
-  root
-    .command("configure")
-    .description("Interactive setup for Opik trace export")
-    .action(async () => {
-      await runOpikConfigure(deps);
-    });
-
-  root
-    .command("status")
-    .description("Show current Opik configuration")
-    .action(() => {
-      showOpikStatus(deps);
-    });
 }

--- a/src/plugin.smoke.test.ts
+++ b/src/plugin.smoke.test.ts
@@ -73,4 +73,14 @@ describe("plugin smoke", () => {
 
     expect(packageJson.dependencies?.zod).toBeTruthy();
   });
+
+  test("package declares built runtime entry for installed OpenClaw loads", () => {
+    const packageJsonPath = new URL("../package.json", import.meta.url);
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+
+    expect(packageJson.openclaw?.extensions).toEqual(["./index.ts"]);
+    expect(packageJson.openclaw?.runtimeExtensions).toEqual(["./dist/index.js"]);
+    expect(packageJson.files).toContain("dist/**");
+    expect(packageJson.scripts?.prepack).toBe("npm run build");
+  });
 });

--- a/src/service.test.ts
+++ b/src/service.test.ts
@@ -33,6 +33,7 @@ const mockWaitForUploads = vi.hoisted(() => vi.fn().mockResolvedValue(undefined)
 const mockResetAttachments = vi.hoisted(() => vi.fn());
 
 vi.mock("opik", () => ({
+  disableLogger: vi.fn(),
   Opik: class {
     trace = mockTraceFn;
     flush = mockFlush;

--- a/src/service.ts
+++ b/src/service.ts
@@ -4,7 +4,7 @@ import type {
   OpenClawPluginService,
 } from "openclaw/plugin-sdk";
 import { onDiagnosticEvent } from "openclaw/plugin-sdk";
-import { Opik, type Span, type Trace } from "opik";
+import type { Opik, Span, Trace } from "opik";
 import { createAttachmentUploader } from "./service/attachment-uploader.js";
 import { registerLlmHooks } from "./service/hooks/llm.js";
 import { registerSubagentHooks } from "./service/hooks/subagent.js";
@@ -663,6 +663,9 @@ export function createOpikService(
       flushRetryBaseDelayMs = asNonNegativeNumber(opikCfg.flushRetryBaseDelayMs) ??
         DEFAULT_FLUSH_RETRY_BASE_DELAY_MS;
 
+      const { disableLogger, Opik } = await import("opik");
+      // Suppress Opik SDK tslog console output once the exporter actually starts.
+      disableLogger();
       client = new Opik({
         apiKey,
         ...(apiUrl ? { apiUrl } : {}),

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": ".",
+    "declaration": true,
+    "declarationMap": false,
+    "sourceMap": false,
+    "types": ["node"]
+  },
+  "include": ["index.ts", "src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.e2e.test.ts"]
+}


### PR DESCRIPTION
## Summary

- Publish built JavaScript for installed OpenClaw runtime loads through `openclaw.runtimeExtensions` while keeping `openclaw.extensions` on the TypeScript source entry.
- Add build/prepack/package-payload checks so release artifacts include the runtime entry OpenClaw loads.
- Split CLI registration into a lightweight module so command setup does not eagerly load configure/runtime dependencies.

## Command performance

Real `~/openclaw`, both installs on `@opik/opik-openclaw@0.2.12`, 5 sequential runs per command.

| Command | Published package | This PR | Gain |
|---|---:|---:|---:|
| `plugins inspect opik-openclaw` mean | `27.29s` | `22.40s` | `17.9% faster` |
| `plugins inspect opik-openclaw` median | `28.34s` | `21.60s` | `23.8% faster` |
| `opik status` mean | `33.63s` | `26.48s` | `21.3% faster` |
| `opik status` median | `32.09s` | `25.36s` | `21.0% faster` |

## Verification

- `npm run build`
- `npm run lint`
- `npm run test`
- `npm run smoke`
- `npm run pack:check`
- Installed into real `~/openclaw` and verified `plugins inspect opik-openclaw` loads `~/.openclaw/extensions/opik-openclaw/dist/index.js`
