### PR TITLE
Record after-only tool observations as spans

### DIFF
--- a/src/service.test.ts
+++ b/src/service.test.ts
@@ -1215,9 +1215,13 @@ describe("opik service", () => {
       expect(mockToolSpan.end).toHaveBeenCalled();
     });
 
-    test("no-ops when no matching tool span", async () => {
+    test("creates an after-only span when no matching tool span exists", async () => {
       const { api, hooks } = createApi();
       const mockTrace = opikState.createMockTrace();
+      const mockLlmSpan = opikState.createMockSpan();
+      const mockToolSpan = opikState.createMockSpan();
+      mockTrace.span.mockReturnValueOnce(mockLlmSpan);
+      mockLlmSpan.span.mockReturnValueOnce(mockToolSpan);
       mockTraceFn.mockReturnValue(mockTrace);
 
       const service = createOpikService(api as any);
@@ -1225,20 +1229,61 @@ describe("opik service", () => {
 
       invokeHook(hooks, "llm_input", { model: "m", provider: "p", prompt: "" }, agentCtx("s1"));
 
-      // Call after_tool_call without a prior before_tool_call
       invokeHook(
         hooks,
         "after_tool_call",
         {
           toolName: "unknown_tool",
+          params: { command: "echo ok" },
           result: "data",
+          runId: "run-1",
+          toolCallId: "native-call-1",
+          durationMs: 25,
         },
         toolCtx("s1"),
       );
 
-      // The LLM span is the only one created — no tool span update/end
-      // trace.span called once for LLM span only (from llm_input)
       expect(mockTrace.span).toHaveBeenCalledTimes(1);
+      expect(mockLlmSpan.span).toHaveBeenCalledWith({
+        name: "unknown_tool",
+        type: "tool",
+        input: { command: "echo ok" },
+        metadata: { durationMs: 25, runId: "run-1", toolCallId: "native-call-1" },
+      });
+      expect(mockToolSpan.update).toHaveBeenCalledWith({
+        input: { command: "echo ok" },
+        metadata: { durationMs: 25, runId: "run-1", toolCallId: "native-call-1" },
+        output: { result: "data" },
+      });
+      expect(mockToolSpan.end).toHaveBeenCalledTimes(1);
+    });
+
+    test("dedupes repeated after-only tool observations by run and tool call id", async () => {
+      const { api, hooks } = createApi();
+      const mockTrace = opikState.createMockTrace();
+      const mockLlmSpan = opikState.createMockSpan();
+      const mockToolSpan = opikState.createMockSpan();
+      mockTrace.span.mockReturnValueOnce(mockLlmSpan);
+      mockLlmSpan.span.mockReturnValueOnce(mockToolSpan);
+      mockTraceFn.mockReturnValue(mockTrace);
+
+      const service = createOpikService(api as any);
+      await service.start(createServiceContext() as any);
+
+      invokeHook(hooks, "llm_input", { model: "m", provider: "p", prompt: "" }, agentCtx("s1"));
+
+      const event = {
+        toolName: "bash",
+        result: { status: "completed" },
+        runId: "run-1",
+        toolCallId: "native-call-1",
+      };
+      invokeHook(hooks, "after_tool_call", event, toolCtx("s1"));
+      invokeHook(hooks, "after_tool_call", event, toolCtx("s1"));
+
+      expect(mockLlmSpan.span).toHaveBeenCalledTimes(1);
+      expect(mockToolSpan.update).toHaveBeenCalledTimes(1);
+      expect(mockToolSpan.end).toHaveBeenCalledTimes(1);
     });
 
     test("falls back when after_tool_call context is missing sessionKey", async () => {

--- a/src/service/hooks/llm.ts
+++ b/src/service/hooks/llm.ts
@@ -127,6 +127,7 @@ export function registerLlmHooks(deps: LlmHooksDeps): void {
         llmSpan,
         toolSpans: new Map(),
         subagentSpans: new Map(),
+        completedToolCallIds: new Set(),
         startedAt: now,
         lastActivityAt: now,
         costMeta: {},

--- a/src/service/hooks/tool.ts
+++ b/src/service/hooks/tool.ts
@@ -30,6 +30,10 @@ type ToolHooksDeps = {
   formatError: (err: unknown) => string;
 };
 
+function completedToolCallKey(runId: string | undefined, toolCallId: string): string {
+  return runId ? `run:${runId}:toolcall:${toolCallId}` : `toolcall:${toolCallId}`;
+}
+
 export function registerToolHooks(deps: ToolHooksDeps): void {
   deps.api.on("before_tool_call", (event, toolCtx) => {
     if (!deps.getClient()) return;
@@ -157,8 +161,6 @@ export function registerToolHooks(deps: ToolHooksDeps): void {
         }
       }
     }
-    if (!matchedKey || !matchedSpan) return;
-
     const spanUpdate: Record<string, unknown> = {};
     if (event.params && typeof event.params === "object" && !Array.isArray(event.params)) {
       spanUpdate.input = sanitizeValueForOpik(event.params) as Record<string, unknown>;
@@ -190,6 +192,31 @@ export function registerToolHooks(deps: ToolHooksDeps): void {
       spanUpdate.output = sanitizeValueForOpik(output) as Record<string, unknown>;
     }
 
+    if (!matchedKey || !matchedSpan) {
+      if (!toolCallId) return;
+      const completedKey = completedToolCallKey(runId, toolCallId);
+      if (active.completedToolCallIds.has(completedKey)) return;
+
+      const toolParent =
+        container.sessionKey === sessionKey && active.llmSpan ? active.llmSpan : container.parent;
+      const spanCreate: Record<string, unknown> = {
+        name: event.toolName,
+        type: "tool",
+        ...(spanUpdate.input ? { input: spanUpdate.input } : {}),
+        ...(spanUpdate.metadata ? { metadata: spanUpdate.metadata } : {}),
+      };
+      try {
+        matchedSpan = toolParent.span(spanCreate as any);
+      } catch (err) {
+        deps.warn(
+          `opik: after-only tool span creation failed (sessionKey=${sessionKey}, tool=${event.toolName}): ${deps.formatError(err)}`,
+        );
+        return;
+      }
+      matchedKey = `after-only:${sessionKey}:${completedKey}`;
+      active.completedToolCallIds.add(completedKey);
+    }
+
     if (Object.keys(spanUpdate).length > 0) {
       deps.safeSpanUpdate(
         matchedSpan,
@@ -210,6 +237,9 @@ export function registerToolHooks(deps: ToolHooksDeps): void {
       matchedSpan,
       `after_tool_call sessionKey=${sessionKey} tool=${event.toolName} key=${matchedKey}`,
     );
+    if (toolCallId) {
+      active.completedToolCallIds.add(completedToolCallKey(runId, toolCallId));
+    }
     active.toolSpans.delete(matchedKey);
   });
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,6 +90,8 @@ export type ActiveTrace = {
     usageCacheWrite?: number;
     usageTotal?: number;
   };
+  /** Tool call ids already closed for this trace, used to dedupe after-only observations. */
+  completedToolCallIds: Set<string>;
   /** Accumulated usage from llm_output events. */
   usage: {
     input?: number;


### PR DESCRIPTION
## Summary

- Record an immediate Opik tool span when `after_tool_call` arrives with a `toolCallId` but no matching open span from `before_tool_call`.
- Deduplicate repeated after-only tool observations by `runId` + `toolCallId` so native replay or duplicate hook delivery does not double-record a tool.
- Keep the existing paired `before_tool_call` / `after_tool_call` path unchanged for normal OpenClaw-owned tools.
- Companion OpenClaw PR: https://github.com/openclaw/openclaw/pull/80372

cc @vincentkoc

## Root Cause

The plugin assumed every `after_tool_call` had a previously-created tool span from `before_tool_call`. That was true for the old OpenClaw-owned tool path, but native tool observations can arrive as after-only completion telemetry when the runtime owns tool execution. When no matching span existed, the plugin returned early and dropped the tool result, so completed native tool calls could disappear from Opik even when OpenClaw emitted a valid `after_tool_call` observation.

## Real Behavior Proof

Behavior fixed: Opik records after-only tool observations as completed tool spans instead of dropping them.

Before:

```text
Code path: src/service/hooks/tool.ts searched active.toolSpans by toolCallId or tool name and returned immediately when no matching span was found.
Existing regression test: the previous no-ops when no matching tool span test asserted that an after-only event created no tool span.
```

After:

```text
npm test -- src/service.test.ts

Test Files  1 passed (1)
Tests  78 passed (78)
```

Observed result:
- The updated after-only test now creates a child tool span under the active LLM span from an `after_tool_call` event carrying `toolCallId`, input params, result, run id, and duration metadata.
- The duplicate test sends the same after-only event twice and proves only one span is created, updated, and ended.

## Verification

- `npm test -- src/service.test.ts`
- `npm run lint`
- `npm run build`
- `git diff --check`

## What was not tested

- Live upload to an Opik backend was not tested; the unit tests verify the plugin span creation/update/end behavior through mocked Opik traces and spans.
- A packaged npm release was not produced; this PR only changes source and tests.