### PR TITLE
ci(clawhub): build runtime before publish so dist/ ships in archive

### DIFF
--- a/.github/workflows/clawhub-package-publish.yml
+++ b/.github/workflows/clawhub-package-publish.yml
@@ -88,6 +88,26 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
+      # ClawHub's package publish packs whatever exists on disk; it does not
+      # honor npm's prepack hook. Build the package here so runtime entries
+      # like dist/index.js are present in the published archive.
+      - name: Setup Node.js
+        if: hashFiles('package.json') != ''
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22.14.0"
+
+      - name: Build package runtime
+        if: hashFiles('package.json') != ''
+        shell: bash
+        run: |
+          if jq -e '.scripts.build' package.json >/dev/null 2>&1; then
+            npm ci --no-audit --no-fund
+            npm run build
+          else
+            echo "No build script in package.json; skipping build step."
+          fi
+
       - uses: oven-sh/setup-bun@e3914758a49697077f7bcd190d36582a61667aad
         with:
           bun-version: 1.3.10

--- a/package-lock.json
+++ b/package-lock.json
@@ -1357,9 +1357,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1376,9 +1373,6 @@
       "integrity": "sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1397,9 +1391,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1417,9 +1408,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1436,9 +1424,6 @@
       "integrity": "sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3323,6 +3308,7 @@
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -3337,6 +3323,7 @@
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -3440,6 +3427,7 @@
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -3544,6 +3532,7 @@
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -4622,6 +4611,7 @@
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -4985,6 +4975,7 @@
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -5289,6 +5280,7 @@
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -5302,6 +5294,7 @@
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5312,6 +5305,7 @@
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -5335,6 +5329,7 @@
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -6060,6 +6055,7 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6329,6 +6325,32 @@
         }
       }
     },
+    "node_modules/opik/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/opik/node_modules/commander": {
       "version": "5.1.0",
       "license": "MIT",
@@ -6447,6 +6469,7 @@
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -6474,6 +6497,7 @@
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -7998,6 +8022,7 @@
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },


### PR DESCRIPTION
## Details

The reusable ClawHub publish workflow does its own `actions/checkout` and invokes the ClawHub CLI directly. The CLI packs whatever exists on disk and does **not** honor npm's `prepack` hook, so a gitignored `dist/` never made it into the published archive. Plugins that declare `runtimeExtensions` pointing at `./dist/*` (this plugin since #81) crash-loop on install with `runtime extension entry not found: ./dist/index.js`.

`release.yml`'s `validate` job already runs `npm ci && npm run build` for npm packaging, which is why npm tarballs ship `dist/` correctly. Only the ClawHub branch of the publish flow was missing this step.

This adds a Setup Node.js step + a conditional `npm ci && npm run build` step right after the package checkout, so ClawHub packs the same runtime artifacts that `npm pack` does. Both steps are gated on `hashFiles('package.json') != ''` and the build step additionally skips if no `scripts.build` is defined, so the reusable workflow stays usable for non-Node plugins.

## Change checklist
- [ ] User facing
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated (if needed)
- [ ] Breaking changes documented (if any)

## Issues
- Resolves #
- OPIK-

## Testing
- Verified locally by packing the source with `npm pack` (which runs `prepack` → `npm run build`), staging the tarball into a docker openclaw container, and installing it via `openclaw plugins install /path/to/tarball`. Archive install triggers `npm install --omit=dev --omit=peer` and the plugin loads cleanly.
- Compared an `@opik/opik-openclaw@0.2.14` clawhub-installed tarball (broken: missing `dist/`) against the same version installed from npm (working: contains `dist/`), confirming the publish-side asymmetry.
- YAML validated with `npx -y js-yaml .github/workflows/clawhub-package-publish.yml`.
- The existing `clawhub-dry-run` CI job (in `ci.yml`) calls this reusable workflow with `dry_run: true`, so this PR's own CI run exercises the change end-to-end. Reviewers can sanity-check the dry-run JSON output to confirm `dist/index.js` is in the packed file list.

## Documentation
No docs change needed; this is publish-pipeline plumbing only.