### PR TITLE
chore(release): v0.2.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opik/opik-openclaw",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opik/opik-openclaw",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opik/opik-openclaw",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "license": "Apache-2.0",
   "description": "OpenClaw Opik exporter — sends LLM traces to Opik",
   "repository": {


### PR DESCRIPTION
## Details

Bumps version to 0.2.16 to ship the ClawHub publish fix from #98.

Once this merges, tagging `v0.2.16` (via a GitHub Release) will trigger `release.yml`, which publishes to both npm and ClawHub. With #98 in place, the ClawHub artifact will include the built `dist/` runtime for the first time since the package's `runtimeExtensions` were declared in #81.

## Change checklist
- [x] User facing
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated (if needed)
- [ ] Breaking changes documented (if any)

## Issues
- Follows up #98

## Testing
- Verified `clawhub-dry-run` from #98 reports `files: 35` and `totalBytes: 698616` — consistent with the built `dist/` (26 files) plus source + package-lock + manifest.
- Verified end-to-end on a docker container by packing source (`npm pack`) and installing via the archive path (`openclaw plugins install <tarball>`); plugin loads, hooks register, traces flow to Opik.

## Documentation
No docs change needed.