### PR TITLE
ci: bump clawhub publish workflow pin

### DIFF
--- a/.github/workflows/clawhub-package-publish.yml
+++ b/.github/workflows/clawhub-package-publish.yml
@@ -116,7 +116,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           repository: openclaw/clawhub
-          ref: 4787be4eb1e06b4ffb947456a6559835a4307f7b
+          ref: b753b1f7ab0e27f230468ba926f805e147da040b
           path: clawhub-source
 
       - name: Install ClawHub CLI dependencies


### PR DESCRIPTION
## Summary

- Bumps the pinned `openclaw/clawhub` checkout used by `clawhub-package-publish.yml` to the current ClawHub `main` release commit (`b753b1f7`).
- Picks up `clawhub@0.17.0`, including the improved scoped-publisher error that tells users to create the missing publisher with `clawhub publisher create ...` before rerunning publish.

## Validation

- Confirmed `openclaw/clawhub` `main` resolves to `b753b1f7ab0e27f230468ba926f805e147da040b`.
- No workflow execution from this fork; change is a one-line workflow pin update.
