### PR TITLE
fix(ci): publish ClawHub package under opik owner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
     uses: ./.github/workflows/clawhub-package-publish.yml
     with:
       dry_run: true
+      owner: opik
 
   clawhub-suspicious-check:
     name: ClawHub suspicious scan

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,6 +205,7 @@ jobs:
     uses: ./.github/workflows/clawhub-package-publish.yml
     with:
       dry_run: false
+      owner: opik
       ref: ${{ needs.validate.outputs.tag_name }}
       version: ${{ needs.validate.outputs.package_version }}
       source_ref: refs/tags/${{ needs.validate.outputs.tag_name }}


### PR DESCRIPTION
## Summary
- pins ClawHub release publishes to the `opik` owner
- pins PR ClawHub dry-runs to the same owner so CI exercises the release shape

## Validation
- `actionlint -shellcheck= .github/workflows/release.yml .github/workflows/ci.yml`
- `git diff --check`
- verified ClawHub package API reports owner `opik` and latest `0.2.14`
- inspected failed v0.2.15 release run: publish command had no owner input and failed with `Publisher "@opik" not found`
- checked current `main` at `57a8ba5`: Node CI and E2E Integration are passing