### PR TITLE
fix(ci): publish built local package to ClawHub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
       id-token: write
     uses: ./.github/workflows/clawhub-package-publish.yml
     with:
+      source: "."
       dry_run: true
       owner: opik
 

--- a/.github/workflows/clawhub-package-publish.yml
+++ b/.github/workflows/clawhub-package-publish.yml
@@ -86,7 +86,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ inputs.ref || github.sha }}
 
       # ClawHub's package publish packs whatever exists on disk; it does not
       # honor npm's prepack hook. Build the package here so runtime entries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
       package_name: ${{ steps.verify.outputs.package_name }}
       package_version: ${{ steps.verify.outputs.package_version }}
       tag_name: ${{ steps.verify.outputs.tag_name }}
+      source_commit: ${{ steps.verify.outputs.source_commit }}
       npm_already_published: ${{ steps.npm_exists.outputs.already_published }}
       clawhub_already_published: ${{ steps.clawhub_exists.outputs.already_published }}
       tarball_name: ${{ steps.pack.outputs.tarball_name }}
@@ -48,6 +49,7 @@ jobs:
         run: |
           PACKAGE_NAME="$(node -p "require('./package.json').name")"
           PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+          SOURCE_COMMIT="$(git rev-parse HEAD)"
 
           if [ -z "$TAG_NAME" ]; then
             echo "tag input is required for workflow_dispatch, and release.tag_name is required for release runs."
@@ -67,6 +69,7 @@ jobs:
           echo "package_name=$PACKAGE_NAME" >> "$GITHUB_OUTPUT"
           echo "package_version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
           echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
+          echo "source_commit=$SOURCE_COMMIT" >> "$GITHUB_OUTPUT"
 
       - name: Check if this version is already published to npm
         id: npm_exists
@@ -204,10 +207,13 @@ jobs:
       id-token: write
     uses: ./.github/workflows/clawhub-package-publish.yml
     with:
+      source: "."
       dry_run: false
       owner: opik
       ref: ${{ needs.validate.outputs.tag_name }}
       version: ${{ needs.validate.outputs.package_version }}
+      source_repo: ${{ github.repository }}
+      source_commit: ${{ needs.validate.outputs.source_commit }}
       source_ref: refs/tags/${{ needs.validate.outputs.tag_name }}
     secrets:
       clawhub_token: ${{ secrets.CLAWHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- publish ClawHub releases from the built local checkout so `dist/index.js` is present
- keep source metadata pinned to the release tag and commit
- make PR ClawHub dry-runs use the same local-source path

## Validation
- `actionlint -shellcheck= .github/workflows/release.yml .github/workflows/ci.yml .github/workflows/clawhub-package-publish.yml`
- `git diff --check`

## Context
The v0.2.16 release published to npm successfully, but ClawHub failed with `runtime extension entry not found: ./dist/index.js` because the workflow built `dist/` locally and then asked ClawHub to publish from the raw GitHub tag source.