### PR TITLE
fix(ci): refresh pinned ClawHub publish source

### DIFF
--- a/.github/workflows/clawhub-package-publish.yml
+++ b/.github/workflows/clawhub-package-publish.yml
@@ -116,7 +116,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           repository: openclaw/clawhub
-          ref: 4787be4eb1e06b4ffb947456a6559835a4307f7b
+          ref: b07196f336ae401e148dbab9cdca3d9286eef689
           path: clawhub-source
 
       - name: Install ClawHub CLI dependencies


### PR DESCRIPTION
## Summary
- refresh the pinned `openclaw/clawhub` checkout used by package publish and suspicious scan workflows
- align the release workflow with the currently deployed ClawHub package publish code path

## Validation
- `actionlint -shellcheck= .github/workflows/ci.yml .github/workflows/clawhub-package-publish.yml .github/workflows/release.yml`
- `git diff --check`

## Context
After fixing local-source publishing, the v0.2.16 ClawHub publish reached the upload path but timed out through the stale pinned ClawHub CLI source.