### PR TITLE
fix(ci): keep ClawHub release artifact clean

### DIFF
--- a/.clawhubignore
+++ b/.clawhubignore
@@ -2,3 +2,5 @@
 # installable ClawHub plugin archive.
 .github/
 .scripts/
+clawhub-source/
+*.tgz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
       source: "."
       dry_run: true
       owner: opik
+      family: code-plugin
 
   clawhub-suspicious-check:
     name: ClawHub suspicious scan

--- a/.github/workflows/clawhub-package-publish.yml
+++ b/.github/workflows/clawhub-package-publish.yml
@@ -36,6 +36,10 @@ on:
         description: Optional owner handle override for org/shared publishing.
         required: false
         type: string
+      family:
+        description: Optional package family override, for example code-plugin or bundle-plugin.
+        required: false
+        type: string
       version:
         description: Optional package version override.
         required: false
@@ -112,15 +116,17 @@ jobs:
         with:
           bun-version: 1.3.10
 
-      # Keep the ClawHub CLI source pinned so workflow behavior stays reproducible.
-      - uses: actions/checkout@v6
-        with:
-          repository: openclaw/clawhub
-          ref: b07196f336ae401e148dbab9cdca3d9286eef689
-          path: clawhub-source
+      - name: Checkout ClawHub CLI source
+        shell: bash
+        run: |
+          set -euo pipefail
+          git init "$RUNNER_TEMP/clawhub-source"
+          git -C "$RUNNER_TEMP/clawhub-source" remote add origin https://github.com/openclaw/clawhub.git
+          git -C "$RUNNER_TEMP/clawhub-source" fetch --depth=1 origin b07196f336ae401e148dbab9cdca3d9286eef689
+          git -C "$RUNNER_TEMP/clawhub-source" checkout --detach FETCH_HEAD
 
       - name: Install ClawHub CLI dependencies
-        working-directory: clawhub-source
+        working-directory: ${{ runner.temp }}/clawhub-source
         run: bun install --frozen-lockfile
 
       - name: Validate publish mode inputs
@@ -183,6 +189,7 @@ jobs:
           INPUT_REF: ${{ inputs.ref }}
           INPUT_DRY_RUN: ${{ inputs.dry_run }}
           INPUT_OWNER: ${{ inputs.owner }}
+          INPUT_FAMILY: ${{ inputs.family }}
           INPUT_VERSION: ${{ inputs.version }}
           INPUT_TAGS: ${{ inputs.tags }}
           INPUT_SOURCE_REPO: ${{ inputs.source_repo }}
@@ -213,7 +220,7 @@ jobs:
               source = f"{source}@{ref}"
 
           cli_entry = (
-              Path(os.environ["GITHUB_WORKSPACE"])
+              Path(os.environ["RUNNER_TEMP"])
               / "clawhub-source"
               / "packages"
               / "clawhub"
@@ -240,10 +247,13 @@ jobs:
           cmd.append("--json")
 
           owner = os.environ["INPUT_OWNER"].strip()
+          family = os.environ["INPUT_FAMILY"].strip()
           version = os.environ["INPUT_VERSION"].strip()
           tags = os.environ["INPUT_TAGS"].strip()
           if owner:
               cmd += ["--owner", owner]
+          if family:
+              cmd += ["--family", family]
           if version:
               cmd += ["--version", version]
           if tags:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,7 @@ jobs:
         env:
           PACKAGE_NAME: ${{ steps.verify.outputs.package_name }}
           PACKAGE_VERSION: ${{ steps.verify.outputs.package_version }}
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
         run: |
           python3 - <<'PY'
           import json
@@ -95,11 +96,15 @@ jobs:
 
           package_name = os.environ["PACKAGE_NAME"].strip()
           package_version = os.environ["PACKAGE_VERSION"].strip()
+          token = os.environ.get("CLAWHUB_TOKEN", "").strip()
           url = f"https://clawhub.ai/api/v1/packages/{urllib.parse.quote(package_name, safe='')}"
 
           already_published = False
+          request = urllib.request.Request(url)
+          if token:
+              request.add_header("Authorization", f"Bearer {token}")
           try:
-              with urllib.request.urlopen(url) as response:
+              with urllib.request.urlopen(request) as response:
                   payload = json.load(response)
           except urllib.error.HTTPError as error:
               if error.code != 404:
@@ -210,6 +215,7 @@ jobs:
       source: "."
       dry_run: false
       owner: opik
+      family: code-plugin
       ref: ${{ needs.validate.outputs.tag_name }}
       version: ${{ needs.validate.outputs.package_version }}
       source_repo: ${{ github.repository }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opik/opik-openclaw",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opik/opik-openclaw",
-      "version": "0.2.16",
+      "version": "0.2.17",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opik/opik-openclaw",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "license": "Apache-2.0",
   "description": "OpenClaw Opik exporter — sends LLM traces to Opik",
   "repository": {


### PR DESCRIPTION
## Summary
- move the pinned ClawHub CLI checkout out of the package workspace so it cannot be packed into the plugin artifact
- pass the package family explicitly for ClawHub dry-run and release publishes
- authenticate the ClawHub already-published probe so blocked owner-visible releases are not mistaken for missing public packages
- bump the package to v0.2.17 after the tainted v0.2.16 ClawHub artifact

## Validation
- `git diff --check`
- `actionlint -shellcheck= .github/workflows/release.yml .github/workflows/clawhub-package-publish.yml .github/workflows/ci.yml`
- `npm run build`
- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run smoke`
- `npm run pack:check`
- `bun /Users/vincentkoc/GIT/_Perso/clawhub/packages/clawhub/src/cli.ts --workdir /Users/vincentkoc/GIT/_Perso/_wt/opik-openclaw-clean-release package publish . --dry-run --json --owner opik --family code-plugin --version 0.2.17 --source-repo comet-ml/opik-openclaw --source-commit $(git rev-parse HEAD) --source-ref refs/tags/v0.2.17`
