### PR TITLE
feat(codex): capture Codex-native tool calls as Opik tool spans

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -239,6 +239,21 @@ jobs:
           fi
           sleep 2
 
+      - name: Symlink global openclaw into node_modules for probe
+        run: |
+          mkdir -p node_modules
+          ln -sf "$(npm root -g)/openclaw" "node_modules/openclaw"
+          node -e "console.error('[probe-prep] openclaw resolves at', require.resolve('openclaw/plugin-sdk/agent-harness-runtime'))"
+
+      - name: Run Codex-runtime probe (OPIK-6509)
+        run: node .scripts/codex-runtime-probe.mjs
+        env:
+          PROBE_OPIK_API_URL: "http://127.0.0.1:18791"
+          PROBE_OPIK_API_KEY: "mock-key"
+          PROBE_OPIK_PROJECT: "e2e-test"
+          PROBE_TOOL_NAME: "codex-probe-shell"
+        timeout-minutes: 1
+
       - name: Stop mock servers and collect results
         run: |
           if [ -f mock-opik.pid ]; then
@@ -251,6 +266,9 @@ jobs:
 
       - name: Assert E2E results
         run: node .scripts/check-e2e-result.mjs
+        env:
+          PROBE_EXPECTED: "1"
+          PROBE_TOOL_NAME: "codex-probe-shell"
 
       - name: Upload E2E result on failure
         if: failure()

--- a/.scripts/check-e2e-result.mjs
+++ b/.scripts/check-e2e-result.mjs
@@ -108,6 +108,35 @@ if (EXPECTED_OPIK_PROJECT) {
   }
 }
 
+const PROBE_TOOL_NAME = process.env.PROBE_TOOL_NAME ?? "codex-probe-shell";
+const PROBE_EXPECTED = process.env.PROBE_EXPECTED === "1";
+
+if (PROBE_EXPECTED) {
+  const probeSpan = findCodexProbeSpan(opikJournal, PROBE_TOOL_NAME);
+  if (!probeSpan) {
+    failures.push(
+      `Codex probe (OPIK-6509): expected a span with metadata.source="codex_app_server" and name="${PROBE_TOOL_NAME}" in the Opik journal — Codex extension factory may not have fired`,
+    );
+  } else {
+    console.log(
+      `[check-e2e] Codex probe: PASS — span name="${probeSpan.name}" toolCallId=${probeSpan.metadata?.toolCallId}`,
+    );
+  }
+}
+
+function findCodexProbeSpan(journal, toolName) {
+  if (!journal?.requests) return undefined;
+  for (const entry of journal.requests) {
+    if (entry.route !== "spans-batch") continue;
+    const spans = entry.body?.spans ?? [];
+    for (const span of spans) {
+      if (span?.name !== toolName) continue;
+      if (span?.metadata?.source === "codex_app_server") return span;
+    }
+  }
+  return undefined;
+}
+
 if (failures.length > 0) {
   console.error("[check-e2e] FAIL:");
   for (const f of failures) console.error("  •", f);

--- a/.scripts/codex-runtime-probe.mjs
+++ b/.scripts/codex-runtime-probe.mjs
@@ -15,10 +15,15 @@
 import { createCodexAppServerToolResultExtensionRunner } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { createOpikService } from "../dist/src/service.js";
 
-const opikApiUrl = process.env.PROBE_OPIK_API_URL ?? "http://127.0.0.1:18791";
-const opikApiKey = process.env.PROBE_OPIK_API_KEY ?? "mock-key";
-const projectName = process.env.PROBE_OPIK_PROJECT ?? "e2e-test";
 const probeMarker = process.env.PROBE_TOOL_NAME ?? "codex-probe-shell";
+
+const probeConfig = {
+  enabled: true,
+  apiKey: process.env.PROBE_OPIK_API_KEY ?? "mock-key",
+  apiUrl: process.env.PROBE_OPIK_API_URL ?? "http://127.0.0.1:18791",
+  projectName: process.env.PROBE_OPIK_PROJECT ?? "e2e-test",
+  workspaceName: "default",
+};
 
 const capturedFactories = [];
 const hooks = {};
@@ -38,31 +43,13 @@ const api = {
       writeConfigFile: async () => undefined,
     },
   },
-  pluginConfig: {
-    enabled: true,
-    apiKey: opikApiKey,
-    apiUrl: opikApiUrl,
-    projectName,
-    workspaceName: "default",
-  },
+  pluginConfig: { ...probeConfig },
 };
 
-const service = createOpikService(api, {
-  enabled: true,
-  apiKey: opikApiKey,
-  apiUrl: opikApiUrl,
-  projectName,
-  workspaceName: "default",
-});
+const service = createOpikService(api, { ...probeConfig });
 
 await service.start({
-  config: {
-    enabled: true,
-    apiKey: opikApiKey,
-    apiUrl: opikApiUrl,
-    projectName,
-    workspaceName: "default",
-  },
+  config: { ...probeConfig },
   logger: {
     info: (message) => console.error(`[probe-info] ${message}`),
     warn: (message) => console.error(`[probe-warn] ${message}`),

--- a/.scripts/codex-runtime-probe.mjs
+++ b/.scripts/codex-runtime-probe.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/**
+ * Codex-runtime E2E probe (OPIK-6509).
+ *
+ * Validates that this plugin's Codex extension factory is correctly invoked by
+ * OpenClaw's real harness runner. Runs OUTSIDE the gateway: spins up a second
+ * instance of the plugin's service pointed at the same mock Opik server, then
+ * drives a synthetic Codex `tool_result` notification through OpenClaw's real
+ * `createCodexAppServerToolResultExtensionRunner`. If the wiring is correct,
+ * the mock Opik journal will contain a span with metadata.source === "codex_app_server".
+ *
+ * Requires: openclaw installed globally (e2e.yml does this), plugin built into dist/.
+ */
+
+import { createCodexAppServerToolResultExtensionRunner } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { createOpikService } from "../dist/src/service.js";
+
+const opikApiUrl = process.env.PROBE_OPIK_API_URL ?? "http://127.0.0.1:18791";
+const opikApiKey = process.env.PROBE_OPIK_API_KEY ?? "mock-key";
+const projectName = process.env.PROBE_OPIK_PROJECT ?? "e2e-test";
+const probeMarker = process.env.PROBE_TOOL_NAME ?? "codex-probe-shell";
+
+const capturedFactories = [];
+const hooks = {};
+
+const api = {
+  on(event, handler) {
+    hooks[event] = handler;
+  },
+  registerService() {},
+  registerCli() {},
+  registerCodexAppServerExtensionFactory(factory) {
+    capturedFactories.push(factory);
+  },
+  runtime: {
+    config: {
+      loadConfig: () => ({}),
+      writeConfigFile: async () => undefined,
+    },
+  },
+  pluginConfig: {
+    enabled: true,
+    apiKey: opikApiKey,
+    apiUrl: opikApiUrl,
+    projectName,
+    workspaceName: "default",
+  },
+};
+
+const service = createOpikService(api, {
+  enabled: true,
+  apiKey: opikApiKey,
+  apiUrl: opikApiUrl,
+  projectName,
+  workspaceName: "default",
+});
+
+await service.start({
+  config: {
+    enabled: true,
+    apiKey: opikApiKey,
+    apiUrl: opikApiUrl,
+    projectName,
+    workspaceName: "default",
+  },
+  logger: {
+    info: (message) => console.error(`[probe-info] ${message}`),
+    warn: (message) => console.error(`[probe-warn] ${message}`),
+  },
+});
+
+if (capturedFactories.length === 0) {
+  console.error(
+    "[probe] FAIL: plugin did not call registerCodexAppServerExtensionFactory — Codex hook is not wired",
+  );
+  process.exit(1);
+}
+
+const sessionKey = "probe-session-1";
+const runId = "probe-run-1";
+
+const llmInputHandler = hooks["llm_input"];
+if (typeof llmInputHandler !== "function") {
+  console.error("[probe] FAIL: plugin did not register an llm_input hook");
+  process.exit(1);
+}
+llmInputHandler(
+  {
+    model: "probe-model",
+    provider: "probe-provider",
+    prompt: "probe",
+    systemPrompt: "probe",
+    imagesCount: 0,
+    sessionId: "probe-session-id-1",
+    runId,
+    historyMessages: [],
+  },
+  {
+    sessionKey,
+    agentId: "probe-agent",
+    messageProvider: "probe",
+    sessionId: "probe-session-id-1",
+    runId,
+  },
+);
+
+const runner = createCodexAppServerToolResultExtensionRunner(
+  {
+    agentId: "probe-agent",
+    sessionId: "probe-session-id-1",
+    sessionKey,
+    runId,
+  },
+  capturedFactories,
+);
+
+const toolResultEvent = {
+  threadId: "probe-thread-1",
+  turnId: "probe-turn-1",
+  toolCallId: "probe-call-1",
+  toolName: probeMarker,
+  args: { cmd: "echo probe" },
+  result: { stdout: "probe-stdout" },
+};
+
+await runner.applyToolResultExtensions(toolResultEvent);
+
+const agentEndHandler = hooks["agent_end"];
+if (typeof agentEndHandler === "function") {
+  agentEndHandler(
+    { success: true, durationMs: 1 },
+    { sessionKey, agentId: "probe-agent", runId },
+  );
+}
+
+await new Promise((resolve) => setTimeout(resolve, 200));
+await service.stop?.({});
+
+console.error(
+  `[probe] OK: drove ${capturedFactories.length} factory(ies) through the harness runner; marker tool="${probeMarker}"`,
+);

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "src/service/payload-sanitizer.ts",
     "src/service/media.ts",
     "src/service/attachment-uploader.ts",
+    "src/service/hooks/codex.ts",
     "src/service/hooks/llm.ts",
     "src/service/hooks/tool.ts",
     "src/service/hooks/subagent.ts",

--- a/src/openclaw-plugin-sdk.d.ts
+++ b/src/openclaw-plugin-sdk.d.ts
@@ -33,6 +33,36 @@ declare module "openclaw/plugin-sdk" {
     stop?: (ctx?: unknown) => void | Promise<void>;
   };
 
+  export type CodexAppServerToolResultEvent = {
+    threadId: string;
+    turnId: string;
+    toolCallId: string;
+    toolName: string;
+    args: Record<string, unknown>;
+    result: unknown;
+  };
+
+  export type CodexAppServerExtensionContext = {
+    agentId?: string;
+    sessionId?: string;
+    sessionKey?: string;
+    runId?: string;
+  };
+
+  export type CodexAppServerExtensionRuntime = {
+    on: (
+      event: "tool_result",
+      handler: (
+        event: CodexAppServerToolResultEvent,
+        ctx: CodexAppServerExtensionContext,
+      ) => void | Promise<void>,
+    ) => void;
+  };
+
+  export type CodexAppServerExtensionFactory = (
+    runtime: CodexAppServerExtensionRuntime,
+  ) => void | Promise<void>;
+
   export type OpenClawPluginApi = {
     pluginConfig?: unknown;
     registerService: (service: OpenClawPluginService) => void;
@@ -40,6 +70,7 @@ declare module "openclaw/plugin-sdk" {
       register: (params: { program: any }) => void,
       options?: { commands?: string[] },
     ) => void;
+    registerCodexAppServerExtensionFactory?: (factory: CodexAppServerExtensionFactory) => void;
     runtime: {
       config: {
         loadConfig: () => OpenClawConfig;

--- a/src/service.test.ts
+++ b/src/service.test.ts
@@ -2931,6 +2931,43 @@ describe("opik service", () => {
       expect(mockToolSpan.end).toHaveBeenCalled();
     });
 
+    test("resolves session via ctx.sessionId when sessionKey is missing", async () => {
+      const { api, hooks, codexHandlers } = createApiWithCodexFactory();
+
+      const mockTraceA = opikState.createMockTrace();
+      const mockTraceB = opikState.createMockTrace();
+      const mockLlmSpanB = opikState.createMockSpan();
+      const mockToolSpan = opikState.createMockSpan();
+      mockTraceB.span.mockReturnValueOnce(mockLlmSpanB);
+      mockLlmSpanB.span.mockReturnValueOnce(mockToolSpan);
+      mockTraceFn
+        .mockReturnValueOnce(mockTraceA)
+        .mockReturnValueOnce(mockTraceB);
+
+      const service = createOpikService(api as any);
+      await service.start(createServiceContext() as any);
+
+      invokeHook(hooks, "llm_input", { model: "m", provider: "p", prompt: "" }, agentCtx("session-a"));
+      invokeHook(hooks, "llm_input", { model: "m", provider: "p", prompt: "" }, agentCtx("session-b"));
+
+      await codexHandlers.tool_result(
+        {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          toolCallId: "call-sid",
+          toolName: "shell",
+          args: { cmd: "ls" },
+          result: { stdout: "ok" },
+        },
+        { sessionId: "session-b" },
+      );
+
+      expect(mockLlmSpanB.span).toHaveBeenCalledWith(
+        expect.objectContaining({ name: "shell", type: "tool" }),
+      );
+      expect(mockToolSpan.end).toHaveBeenCalled();
+    });
+
     test("drops the event when no active trace exists for the session", async () => {
       const { api, codexHandlers } = createApiWithCodexFactory();
 

--- a/src/service.test.ts
+++ b/src/service.test.ts
@@ -2772,4 +2772,187 @@ describe("opik service", () => {
       await expect(service.stop?.({} as any)).resolves.toBeUndefined();
     });
   });
+
+  // =========================================================================
+  // Codex app-server tool_result hook (OPIK-6509)
+  // =========================================================================
+  describe("codex tool_result hook", () => {
+    function createApiWithCodexFactory() {
+      const hooks: Record<string, Function> = {};
+      const codexHandlers: Record<string, Function> = {};
+      const registerCodexAppServerExtensionFactory = vi.fn(async (factory: Function) => {
+        await factory({
+          on: (event: string, handler: Function) => {
+            codexHandlers[event] = handler;
+          },
+        });
+      });
+      const api = {
+        on: vi.fn((hookName: string, handler: Function) => {
+          hooks[hookName] = handler;
+        }),
+        registerService: vi.fn(),
+        registerCodexAppServerExtensionFactory,
+      };
+      return { api, hooks, codexHandlers, registerCodexAppServerExtensionFactory };
+    }
+
+    test("does not throw when host lacks registerCodexAppServerExtensionFactory", async () => {
+      const { api } = createApi();
+      const service = createOpikService(api as any);
+      await expect(service.start(createServiceContext() as any)).resolves.toBeUndefined();
+    });
+
+    test("registers a Codex extension factory at service start", async () => {
+      const { api, registerCodexAppServerExtensionFactory } = createApiWithCodexFactory();
+      const service = createOpikService(api as any);
+      await service.start(createServiceContext() as any);
+
+      expect(registerCodexAppServerExtensionFactory).toHaveBeenCalledTimes(1);
+    });
+
+    test("creates a Codex tool span under llm span and ends it on tool_result", async () => {
+      const { api, hooks, codexHandlers } = createApiWithCodexFactory();
+
+      const mockTrace = opikState.createMockTrace();
+      const mockLlmSpan = opikState.createMockSpan();
+      const mockToolSpan = opikState.createMockSpan();
+      mockTrace.span.mockReturnValueOnce(mockLlmSpan);
+      mockLlmSpan.span.mockReturnValueOnce(mockToolSpan);
+      mockTraceFn.mockReturnValue(mockTrace);
+
+      const service = createOpikService(api as any);
+      await service.start(createServiceContext() as any);
+
+      invokeHook(hooks, "llm_input", { model: "m", provider: "p", prompt: "" }, agentCtx("s1"));
+
+      const handler = codexHandlers.tool_result;
+      expect(handler).toBeDefined();
+      await handler(
+        {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          toolCallId: "call-1",
+          toolName: "shell",
+          args: { cmd: "ls" },
+          result: { stdout: "a\nb" },
+        },
+        { sessionKey: "s1", sessionId: "session-1", agentId: "agent-1", runId: "run-1" },
+      );
+
+      expect(mockLlmSpan.span).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "shell",
+          type: "tool",
+          input: { cmd: "ls" },
+          output: { stdout: "a\nb" },
+          metadata: expect.objectContaining({
+            source: "codex_app_server",
+            threadId: "thread-1",
+            turnId: "turn-1",
+            toolCallId: "call-1",
+            agentId: "agent-1",
+            sessionId: "session-1",
+            runId: "run-1",
+          }),
+        }),
+      );
+      expect(mockToolSpan.end).toHaveBeenCalled();
+    });
+
+    test("records error result with errorInfo and CodexToolError type", async () => {
+      const { api, hooks, codexHandlers } = createApiWithCodexFactory();
+
+      const mockTrace = opikState.createMockTrace();
+      const mockLlmSpan = opikState.createMockSpan();
+      const mockToolSpan = opikState.createMockSpan();
+      mockTrace.span.mockReturnValueOnce(mockLlmSpan);
+      mockLlmSpan.span.mockReturnValueOnce(mockToolSpan);
+      mockTraceFn.mockReturnValue(mockTrace);
+
+      const service = createOpikService(api as any);
+      await service.start(createServiceContext() as any);
+
+      invokeHook(hooks, "llm_input", { model: "m", provider: "p", prompt: "" }, agentCtx("s1"));
+
+      await codexHandlers.tool_result(
+        {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          toolCallId: "call-2",
+          toolName: "shell",
+          args: { cmd: "nope" },
+          result: { error: "command not found" },
+        },
+        { sessionKey: "s1" },
+      );
+
+      expect(mockLlmSpan.span).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "shell",
+          output: { error: "command not found" },
+          errorInfo: expect.objectContaining({
+            exceptionType: "CodexToolError",
+            message: "command not found",
+          }),
+        }),
+      );
+      expect(mockToolSpan.end).toHaveBeenCalled();
+    });
+
+    test("falls back to single active session when ctx.sessionKey is missing", async () => {
+      const { api, hooks, codexHandlers } = createApiWithCodexFactory();
+
+      const mockTrace = opikState.createMockTrace();
+      const mockLlmSpan = opikState.createMockSpan();
+      const mockToolSpan = opikState.createMockSpan();
+      mockTrace.span.mockReturnValueOnce(mockLlmSpan);
+      mockLlmSpan.span.mockReturnValueOnce(mockToolSpan);
+      mockTraceFn.mockReturnValue(mockTrace);
+
+      const service = createOpikService(api as any);
+      await service.start(createServiceContext() as any);
+
+      invokeHook(hooks, "llm_input", { model: "m", provider: "p", prompt: "" }, agentCtx("s1"));
+
+      await codexHandlers.tool_result(
+        {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          toolCallId: "call-3",
+          toolName: "shell",
+          args: {},
+          result: { ok: true },
+        },
+        {},
+      );
+
+      expect(mockLlmSpan.span).toHaveBeenCalled();
+      expect(mockToolSpan.end).toHaveBeenCalled();
+    });
+
+    test("drops the event when no active trace exists for the session", async () => {
+      const { api, codexHandlers } = createApiWithCodexFactory();
+
+      const mockTrace = opikState.createMockTrace();
+      mockTraceFn.mockReturnValue(mockTrace);
+
+      const service = createOpikService(api as any);
+      await service.start(createServiceContext() as any);
+
+      await codexHandlers.tool_result(
+        {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          toolCallId: "call-4",
+          toolName: "shell",
+          args: {},
+          result: { ok: true },
+        },
+        { sessionKey: "unknown-session" },
+      );
+
+      expect(mockTrace.span).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/service.ts
+++ b/src/service.ts
@@ -6,6 +6,7 @@ import type {
 import { onDiagnosticEvent } from "openclaw/plugin-sdk";
 import type { Opik, Span, Trace } from "opik";
 import { createAttachmentUploader } from "./service/attachment-uploader.js";
+import { registerCodexHooks } from "./service/hooks/codex.js";
 import { registerLlmHooks } from "./service/hooks/llm.js";
 import { registerSubagentHooks } from "./service/hooks/subagent.js";
 import { registerToolHooks } from "./service/hooks/tool.js";
@@ -555,6 +556,21 @@ export function createOpikService(
       forgetSubagentSpanHost,
       safeSpanUpdate,
       safeSpanEnd,
+      warn: (message) => log.warn(message),
+      formatError,
+    });
+
+    registerCodexHooks({
+      api,
+      getClient: () => client,
+      activeTraces,
+      sessionByAgentId,
+      getLastActiveSessionKey: () => lastActiveSessionKey,
+      rememberSessionCorrelation,
+      resolveSessionSpanContainer,
+      safeSpanEnd,
+      scheduleMediaAttachmentUploads: attachmentUploader.scheduleMediaAttachmentUploads,
+      getProjectName: () => currentProjectName,
       warn: (message) => log.warn(message),
       formatError,
     });

--- a/src/service/hooks/codex.ts
+++ b/src/service/hooks/codex.ts
@@ -113,6 +113,9 @@ function resolveSessionKey(
   if (ctx.sessionKey && deps.activeTraces.has(ctx.sessionKey)) {
     return ctx.sessionKey;
   }
+  if (ctx.sessionId && deps.activeTraces.has(ctx.sessionId)) {
+    return ctx.sessionId;
+  }
   if (ctx.agentId) {
     const byAgentId = deps.sessionByAgentId.get(ctx.agentId);
     if (byAgentId && deps.activeTraces.has(byAgentId)) {

--- a/src/service/hooks/codex.ts
+++ b/src/service/hooks/codex.ts
@@ -1,0 +1,155 @@
+import type {
+  CodexAppServerExtensionContext,
+  CodexAppServerToolResultEvent,
+  OpenClawPluginApi,
+} from "openclaw/plugin-sdk";
+import type { Opik, Span, Trace } from "opik";
+import type { ActiveTrace } from "../../types.js";
+import { sanitizeStringForOpik, sanitizeValueForOpik } from "../payload-sanitizer.js";
+
+type CodexHooksDeps = {
+  api: OpenClawPluginApi;
+  getClient: () => Opik | null;
+  activeTraces: Map<string, ActiveTrace>;
+  sessionByAgentId: Map<string, string>;
+  getLastActiveSessionKey: () => string | undefined;
+  rememberSessionCorrelation: (sessionKey: string, agentId?: unknown) => void;
+  resolveSessionSpanContainer: (
+    sessionKey: string,
+  ) => { sessionKey: string; active: ActiveTrace; parent: Trace | Span } | undefined;
+  safeSpanEnd: (span: Span, reason: string) => void;
+  scheduleMediaAttachmentUploads: (params: {
+    entityType: "trace" | "span";
+    entity: unknown;
+    projectName: string;
+    reason: string;
+    payloads: unknown[];
+  }) => void;
+  getProjectName: () => string;
+  warn: (message: string) => void;
+  formatError: (err: unknown) => string;
+};
+
+export function registerCodexHooks(deps: CodexHooksDeps): void {
+  const register = deps.api.registerCodexAppServerExtensionFactory;
+  if (typeof register !== "function") {
+    return;
+  }
+
+  register((runtime) => {
+    runtime.on("tool_result", (event, ctx) => {
+      handleCodexToolResult(deps, event, ctx);
+    });
+  });
+}
+
+function handleCodexToolResult(
+  deps: CodexHooksDeps,
+  event: CodexAppServerToolResultEvent,
+  ctx: CodexAppServerExtensionContext,
+): void {
+  if (!deps.getClient()) return;
+
+  const sessionKey = resolveSessionKey(deps, ctx);
+  if (!sessionKey) return;
+  deps.rememberSessionCorrelation(sessionKey, ctx.agentId);
+
+  const container = deps.resolveSessionSpanContainer(sessionKey);
+  if (!container) return;
+  const active = container.active;
+  const parent = active.llmSpan ?? container.parent;
+
+  active.lastActivityAt = Date.now();
+
+  const { output, errorInfo } = extractResult(event.result);
+
+  const metadata: Record<string, unknown> = {
+    source: "codex_app_server",
+    ...(ctx.agentId ? { agentId: ctx.agentId } : {}),
+    ...(ctx.sessionId ? { sessionId: ctx.sessionId } : {}),
+    ...(ctx.runId ? { runId: ctx.runId } : {}),
+    ...(event.threadId ? { threadId: event.threadId } : {}),
+    ...(event.turnId ? { turnId: event.turnId } : {}),
+    ...(event.toolCallId ? { toolCallId: event.toolCallId } : {}),
+  };
+
+  let toolSpan: Span;
+  try {
+    toolSpan = parent.span({
+      name: event.toolName,
+      type: "tool",
+      input: sanitizeValueForOpik(event.args) as any,
+      ...(output !== undefined ? { output: output as any } : {}),
+      ...(errorInfo ? { errorInfo } : {}),
+      metadata,
+    });
+  } catch (err) {
+    deps.warn(
+      `opik: codex tool span creation failed (sessionKey=${sessionKey}, tool=${event.toolName}): ${deps.formatError(err)}`,
+    );
+    return;
+  }
+
+  deps.scheduleMediaAttachmentUploads({
+    entityType: "span",
+    entity: toolSpan,
+    projectName: deps.getProjectName(),
+    reason: `codex_app_server.tool_result sessionKey=${sessionKey} tool=${event.toolName}`,
+    payloads: [event.args, event.result],
+  });
+
+  deps.safeSpanEnd(
+    toolSpan,
+    `codex_app_server.tool_result sessionKey=${sessionKey} tool=${event.toolName} toolCallId=${event.toolCallId}`,
+  );
+}
+
+function resolveSessionKey(
+  deps: CodexHooksDeps,
+  ctx: CodexAppServerExtensionContext,
+): string | undefined {
+  if (ctx.sessionKey && deps.activeTraces.has(ctx.sessionKey)) {
+    return ctx.sessionKey;
+  }
+  if (ctx.agentId) {
+    const byAgentId = deps.sessionByAgentId.get(ctx.agentId);
+    if (byAgentId && deps.activeTraces.has(byAgentId)) {
+      return byAgentId;
+    }
+  }
+  if (deps.activeTraces.size === 1) {
+    return deps.activeTraces.keys().next().value as string | undefined;
+  }
+  const last = deps.getLastActiveSessionKey();
+  if (last && deps.activeTraces.has(last)) {
+    return last;
+  }
+  return undefined;
+}
+
+function extractResult(
+  result: unknown,
+): { output?: Record<string, unknown>; errorInfo?: Record<string, unknown> } {
+  if (result === undefined || result === null) {
+    return {};
+  }
+
+  if (typeof result === "object" && !Array.isArray(result)) {
+    const resultObj = result as Record<string, unknown>;
+    const errorField = resultObj.error;
+    if (typeof errorField === "string" && errorField.length > 0) {
+      const sanitized = sanitizeStringForOpik(errorField);
+      return {
+        output: { error: sanitized },
+        errorInfo: {
+          exceptionType: "CodexToolError",
+          message: sanitized,
+          traceback: sanitized,
+        },
+      };
+    }
+    return { output: sanitizeValueForOpik(resultObj) as Record<string, unknown> };
+  }
+
+  return { output: { result: sanitizeValueForOpik(result) } };
+}

--- a/src/service/hooks/codex.ts
+++ b/src/service/hooks/codex.ts
@@ -73,16 +73,18 @@ function handleCodexToolResult(
     ...(event.toolCallId ? { toolCallId: event.toolCallId } : {}),
   };
 
+  const spanPayload: Record<string, unknown> = {
+    name: event.toolName,
+    type: "tool",
+    input: sanitizeValueForOpik(event.args),
+    ...(output !== undefined ? { output } : {}),
+    ...(errorInfo ? { errorInfo } : {}),
+    metadata,
+  };
+
   let toolSpan: Span;
   try {
-    toolSpan = parent.span({
-      name: event.toolName,
-      type: "tool",
-      input: sanitizeValueForOpik(event.args) as any,
-      ...(output !== undefined ? { output: output as any } : {}),
-      ...(errorInfo ? { errorInfo } : {}),
-      metadata,
-    });
+    toolSpan = parent.span(spanPayload as any);
   } catch (err) {
     deps.warn(
       `opik: codex tool span creation failed (sessionKey=${sessionKey}, tool=${event.toolName}): ${deps.formatError(err)}`,
@@ -127,9 +129,15 @@ function resolveSessionKey(
   return undefined;
 }
 
+type CodexErrorInfo = {
+  exceptionType: string;
+  message: string;
+  traceback: string;
+};
+
 function extractResult(
   result: unknown,
-): { output?: Record<string, unknown>; errorInfo?: Record<string, unknown> } {
+): { output?: Record<string, unknown>; errorInfo?: CodexErrorInfo } {
   if (result === undefined || result === null) {
     return {};
   }


### PR DESCRIPTION
# User description

<img width="1920" height="3056" alt="image" src="https://github.com/user-attachments/assets/c1d839cc-9424-4e4e-a0c8-2a5110f82f17" />

## Summary

Closes #90. Refs [OPIK-6509](https://comet-ml.atlassian.net/browse/OPIK-6509).

OpenClaw's `before_tool_call` / `after_tool_call` hooks only fire for OpenClaw-owned dynamic tools. Codex-native tools — shell, patch, MCP — bypass them, so the plugin was missing them from Opik traces entirely (LLM spans showed up, but no tool spans for Codex's own work).

This PR subscribes the plugin to `codex.on("tool_result", ...)` via OpenClaw's optional `registerCodexAppServerExtensionFactory` API and records an Opik `tool` span for each Codex-native tool completion.

## Design

- **Optional, gracefully degraded.** `registerCodexAppServerExtensionFactory` is declared optional in the local SDK stub and probed at runtime — older OpenClaw hosts that don't expose the method silently skip Codex hook registration. No `peerDependencies` bump.
- **Span shape.** Tool span nested under the active LLM span when present, otherwise under the trace. Metadata records the source (`codex_app_server`) plus `threadId`, `turnId`, `toolCallId`, `agentId`, `sessionId`, `runId`.
- **Session correlation.** Reuses the same fallback chain as the existing `after_tool_call` path: explicit `sessionKey` → `sessionByAgentId` → single active trace → last active session.
- **Error path.** When the Codex tool result is `{ error: "…" }`, the span gets `errorInfo` with `exceptionType: "CodexToolError"`, mirroring the existing tool-hook convention.

## Validation

| Layer | Coverage |
|---|---|
| **Vitest unit tests** (`service.test.ts`) | 5 new cases: graceful no-op when host lacks the API, factory registered exactly once, happy-path span shape, error-path `errorInfo`, session-fallback when `ctx.sessionKey` is missing, drop-when-no-active-trace |
| **CI build + typecheck** (`ci.yml`) | Confirms the new code compiles against opik's strict `SpanData` types and the existing tests still pass |
| **Codex-runtime e2e probe** (`e2e.yml`, new) | Imports the **real** `createCodexAppServerToolResultExtensionRunner` from globally-installed openclaw, hands it this plugin's factory, fires a synthetic `tool_result` event, and asserts the mock Opik server's journal contains a span with `metadata.source === "codex_app_server"` and the expected tool name |

**Latest CI run confirmed all three layers pass.** The probe's assertion line in the e2e log:
```
[probe] OK: drove 1 factory(ies) through the harness runner; marker tool="codex-probe-shell"
[check-e2e] Codex probe: PASS — span name="codex-probe-shell" toolCallId=probe-call-1
```

That output proves: (1) the plugin's factory registration is wired correctly, (2) OpenClaw's actual runner accepts our factory shape, (3) our handler is invoked when the runner sees a `tool_result` event, and (4) the resulting Opik span reaches the backend with the right metadata marker.

## Known limitations

- **Result-only span by design.** OpenClaw's contract exposes only an async `tool_result` observation for Codex-native tools, with no pre-event. Span is synthesized at result time using `event.args` as input.
- **MCP-payload gating.** Per OpenClaw docs, MCP tool calls flow through this path only on Codex app-server `≥0.125.0`. On older app-server versions, MCP tool calls remain invisible. No version detection in this PR — would be a small follow-up.
- **Real-Codex behaviour assumed.** The e2e probe synthesizes the event; it doesn't exercise the real-Codex → OpenClaw edge. A confirmed real-world test (e.g., the reporter from #90 trying the branch with a live Telegram/Codex setup) would close the remaining gap.

## How `peerDependencies` is honored

PR #5 deliberately keeps `openclaw` as a peer-only dependency to avoid pulling AWS/Smithy into every local `npm ci`. The new e2e probe respects that:

```yaml
- name: Symlink global openclaw into node_modules for probe
  run: ln -sf "$(npm root -g)/openclaw" "node_modules/openclaw"
```

The probe uses the same global install that `e2e.yml` already does for the gateway — no new download, no `devDependencies` change, no lockfile pollution.


[OPIK-6509]: https://comet-ml.atlassian.net/browse/OPIK-6509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
registerHooks_("registerHooks"):::modified
registerCodexHooks_("registerCodexHooks"):::added
handleCodexToolResult_("handleCodexToolResult"):::added
resolveSessionKey_("resolveSessionKey"):::added
extractResult_("extractResult"):::added
CodexAppServerToolResultEvent_("CodexAppServerToolResultEvent"):::added
CodexAppServerExtensionContext_("CodexAppServerExtensionContext"):::added
registerHooks_ -- "Wires Codex tool_result hook registration into service initialization." --> registerCodexHooks_
registerCodexHooks_ -- "Registers handleCodexToolResult to process incoming Codex tool_result events." --> handleCodexToolResult_
handleCodexToolResult_ -- "Resolves active sessionKey from context before tracing tool result." --> resolveSessionKey_
handleCodexToolResult_ -- "Extracts and sanitizes tool output or error into span payload." --> extractResult_
handleCodexToolResult_ -- "Uses event toolName, args, result to build tool span." --> CodexAppServerToolResultEvent_
handleCodexToolResult_ -- "Consumes context agentId/sessionId/sessionKey to correlate tracing session." --> CodexAppServerExtensionContext_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Hook into Codex app-server <code>tool_result</code> events through the optional OpenClaw extension API so <code>tool</code> spans now capture sanitized payloads, metadata, and session correlation, with SDK typings and unit tests guarding the integration. Validate the full flow by driving a Codex runtime probe in CI that registers the factory via the real harness and asserts the tagged span reaches the mock Opik journal.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/comet-ml/opik-openclaw/114?tool=ast&topic=Codex+probe>Codex probe</a>
        </td><td>Drive a Codex-runtime probe through CI by symlinking the global OpenClaw install, running the new <code>.scripts/codex-runtime-probe.mjs</code>, and having <code>.scripts/check-e2e-result.mjs</code> assert that the mock Opik journal contains the expected span, ensuring the registered factory is invoked in the real harness.<details><summary>Modified files (3)</summary><ul><li>.github/workflows/e2e.yml</li>
<li>.scripts/check-e2e-result.mjs</li>
<li>.scripts/codex-runtime-probe.mjs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>danield@comet.com</td><td>fix(codex): use ctx.se...</td><td>May 26, 2026</td></tr>
<tr><td>vincentkoc@ieee.org</td><td>fix(e2e): allow opik c...</td><td>May 06, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/comet-ml/opik-openclaw/114?tool=ast&topic=Codex+tool+spans>Codex tool spans</a>
        </td><td>Emit Codex-native tool results as Opik <code>tool</code> spans by hooking <code>registerCodexHooks</code> into the service, wiring the optional <code>registerCodexAppServerExtensionFactory</code> API via the SDK types, sanitizing/recording payloads, and covering the behavior with focused Vitest cases (graceful no-op, span shape, error metadata, and session fallbacks).<details><summary>Modified files (5)</summary><ul><li>package.json</li>
<li>src/openclaw-plugin-sdk.d.ts</li>
<li>src/service.test.ts</li>
<li>src/service.ts</li>
<li>src/service/hooks/codex.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>danield@comet.com</td><td>fix(codex): use ctx.se...</td><td>May 26, 2026</td></tr>
<tr><td>vincentkoc@ieee.org</td><td>fix(ci): keep ClawHub ...</td><td>May 22, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/comet-ml/opik-openclaw/114?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>