### PR TITLE
[OPIK-6871] [SDK] fix: ignore media:// authority URIs in local media extraction

### DIFF
--- a/src/service/attachment-uploader.test.ts
+++ b/src/service/attachment-uploader.test.ts
@@ -218,6 +218,31 @@ describe("attachment uploader", () => {
     expect(attachmentsApi.startMultiPartUpload).not.toHaveBeenCalled();
   });
 
+  test("ignores OpenClaw media:// authority URIs without attempting an upload or warning", async () => {
+    const attachmentsApi = createAttachmentsApi();
+    const client = { api: { attachments: attachmentsApi } };
+    const onWarn = vi.fn();
+
+    const uploader = createAttachmentUploader({
+      getClient: () => client as unknown as Opik,
+      getAttachmentBaseUrl: () => "https://www.comet.com/opik/api",
+      onWarn,
+      formatError: (err) => String(err),
+    });
+
+    uploader.scheduleMediaAttachmentUploads({
+      entityType: "trace",
+      entity: { id: "trace-1" },
+      projectName: "openclaw",
+      reason: "media-authority-uri",
+      payloads: ["media://inbound/example.jpg"],
+    });
+    await uploader.waitForUploads();
+
+    expect(attachmentsApi.startMultiPartUpload).not.toHaveBeenCalled();
+    expect(onWarn).not.toHaveBeenCalled();
+  });
+
   test("uploads multipart attachments without loading the whole file into one request body", async () => {
     const largeContents = Buffer.alloc(ATTACHMENT_UPLOAD_PART_SIZE_BYTES + 32, 0x61);
     const { dir, filePath } = await createTempMediaFile(".png", largeContents);

--- a/src/service/media.test.ts
+++ b/src/service/media.test.ts
@@ -14,6 +14,18 @@ describe("media path extraction", () => {
     expect([...target]).toEqual(["/tmp/image.png"]);
   });
 
+  test("ignores media:// authority URIs instead of normalizing them to local paths", () => {
+    const target = new Set<string>();
+    collectMediaPathsFromString("media://inbound/example.jpg", target);
+    expect(target.size).toBe(0);
+  });
+
+  test("ignores media:// authority URIs with a host segment", () => {
+    const target = new Set<string>();
+    collectMediaPathsFromString("see media://host/path/to/example.jpg now", target);
+    expect(target.size).toBe(0);
+  });
+
   test("collects file:// local path references", () => {
     const target = new Set<string>();
     collectMediaPathsFromString("open file:///tmp/image.png", target);

--- a/src/service/media.ts
+++ b/src/service/media.ts
@@ -30,8 +30,10 @@ const MEDIA_EXTENSIONS = new Set([
   ".mkv",
 ]);
 
+// Reject the media:// authority form (e.g. OpenClaw media://inbound/...) — those are
+// logical URIs, not local paths, and must not be normalized to /inbound/... and stat'd.
 const MEDIA_SCHEME_LOCAL_PATH_RE =
-  /\bmedia:((?:~\/|\/)[^\s"'`]+?\.(?:png|jpe?g|gif|webp|bmp|tiff?|heic|heif|svg|mp3|wav|m4a|aac|ogg|oga|flac|opus|caf|weba|webm|mp4|mov|mkv))(?=[\s"'`]|$)/gi;
+  /\bmedia:(?!\/\/)((?:~\/|\/)[^\s"'`]+?\.(?:png|jpe?g|gif|webp|bmp|tiff?|heic|heif|svg|mp3|wav|m4a|aac|ogg|oga|flac|opus|caf|weba|webm|mp4|mov|mkv))(?=[\s"'`]|$)/gi;
 
 const FILE_SCHEME_LOCAL_PATH_RE =
   /\bfile:\/\/((?:~\/|\/)[^\s"'`]+?\.(?:png|jpe?g|gif|webp|bmp|tiff?|heic|heif|svg|mp3|wav|m4a|aac|ogg|oga|flac|opus|caf|weba|webm|mp4|mov|mkv))(?:\?[^\s"'`]*)?(?=[\s"'`]|$)/gi;


### PR DESCRIPTION
# User description
## Details

<img width="1920" height="2048" alt="image" src="https://github.com/user-attachments/assets/1c1f20e2-af38-406b-a640-45981fc287bd" />

OpenClaw `media://inbound/...` URIs were being treated as local absolute file paths. The `media:` local-path regex in `media.ts` allowed a leading `/`, so `media://inbound/example.jpg` matched and was normalized to `/inbound/example.jpg`. The attachment uploader then `stat`'d that non-existent path and logged an `ENOENT` warning, dropping the attachment.

The fix adds a negative lookahead `(?!\/\/)` after `media:` so the `media://` authority form is no longer captured. Legitimate local references — `media:/abs/path.jpg` and `media:~/path.jpg` — still resolve unchanged.

Resolution via `$OPENCLAW_STATE_DIR` (the other option in the issue) was deliberately not taken: the codebase has no existing reference to that env var, the name itself arrived through a lossy sync, and adding that coupling would silently no-op if the name were wrong. `media://` URIs are never local paths, so ignoring them is the correct fix regardless. Proper inbound-media resolution can follow once an OpenClaw state-dir contract is confirmed.

## Change checklist
- [x] User facing
- [ ] Documentation updated (if needed)
- [x] Tests added/updated (if needed)
- [ ] Breaking changes documented (if any)

## Issues
- Resolves #115
- OPIK-6871

## Testing

Added two regression tests in `src/service/media.test.ts`:
- `media://inbound/example.jpg` (exact issue repro) collects nothing
- `media://host/path/to/example.jpg` (authority + host segment) collects nothing

Existing positive cases (`media:/tmp/image.png`, `file://`, markdown links) still pass. Full suite: 104 passed / 1 skipped; `tsc --noEmit` clean.

## Documentation

N/A

---

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Ignore OpenClaw <code>media://</code> authority references when detecting local media so <code>media.ts</code> no longer normalizes them and the attachment uploader stops treating them as files. Add regression tests for <code>collectMediaPathsFromString</code> and the uploader to ensure those URIs are skipped without warnings.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/comet-ml/opik-openclaw/126?tool=ast&topic=Media+URI+parsing>Media URI parsing</a>
        </td><td>Add a negative lookahead to <code>MEDIA_SCHEME_LOCAL_PATH_RE</code> so <code>media://</code> authority URIs are excluded while local <code>media:/</code> paths remain normalized.<details><summary>Modified files (2)</summary><ul><li>src/service/media.test.ts</li>
<li>src/service/media.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>danield@comet.com</td><td>[OPIK-6871] [SDK] fix:...</td><td>June 16, 2026</td></tr>
<tr><td>vincentkoc@ieee.org</td><td>Require explicit local...</td><td>March 06, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/comet-ml/opik-openclaw/126?tool=ast&topic=Uploader+guard>Uploader guard</a>
        </td><td>Add behavior verification that <code>scheduleMediaAttachmentUploads</code> ignores <code>media://</code> authority URIs and never calls the attachments API or emits warnings.<details><summary>Modified files (1)</summary><ul><li>src/service/attachment-uploader.test.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>danield@comet.com</td><td>test(media): cover med...</td><td>June 16, 2026</td></tr>
<tr><td>vincentkoc@ieee.org</td><td>Require explicit local...</td><td>March 06, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/comet-ml/opik-openclaw/126?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

[OPIK-6871]: https://comet-ml.atlassian.net/browse/OPIK-6871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ