### PR TITLE
[OPIK-6973] [INFRA] feat: local Docker support to test opik-openclaw PR/branch builds E2E

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+dist
+.git
+.github
+.claude
+.artifacts
+*.tgz
+.env
+.env.*
+screenshot.png
+diagrams

--- a/README.md
+++ b/README.md
@@ -228,6 +228,75 @@ Notes:
 - falls back to `npx openclaw@${OPENCLAW_LIVE_OPENCLAW_VERSION:-latest}` when `openclaw` is not already on your `PATH`
 - override the live model with `OPENCLAW_LIVE_MODEL` if `gpt-4o-mini` is not what you want to exercise
 
+## Local Docker E2E testing
+
+When reviewing a PR or branch, you can install that build into OpenClaw inside an
+isolated, disposable Docker container and manually verify that LLM/tool spans land
+in your own Opik project — no host OpenClaw setup required and nothing persists on
+the host.
+
+Prerequisites:
+
+- Docker
+- Node.js `>=22.12.0` and npm `>=10` (used on the host to pack the plugin)
+- An Opik project plus an `OPENAI_API_KEY` for the live model call
+- Optional: the GitHub `gh` CLI (used to check out PRs, including forks)
+
+Set the required credentials in your shell or in a gitignored `.env` (copy from
+`.env.example`):
+
+```bash
+export OPIK_API_KEY="your-api-key"
+export OPIK_URL_OVERRIDE="https://www.comet.com/opik/api"
+export OPENAI_API_KEY="sk-..."
+# optional: OPIK_PROJECT_NAME (default openclaw), OPIK_WORKSPACE (default default)
+```
+
+Run a PR, a branch, or the current working tree:
+
+```bash
+./scripts/test-local.sh 114                 # check out PR #114 and test it
+./scripts/test-local.sh my-feature-branch   # test a branch
+./scripts/test-local.sh --current           # test the current working tree as-is
+```
+
+The host runs only git: it checks out the PR/branch and exports a source snapshot
+with `git archive` (which executes no project code). The snapshot is mounted
+read-only into a clean Node 22 image that runs `openclaw@2026.3.2` (override with
+`OPENCLAW_VERSION`); the container does `npm ci && npm pack`, installs the build,
+starts the gateway, and drops you into a shell. Run a turn that triggers tool
+calls, e.g.:
+
+```bash
+openclaw agent --agent main --message "Use the shell tool to run 'echo hello', then reply done."
+```
+
+Then open your Opik project and confirm the trace shows an LLM span and a tool span
+(e.g. `shell` / `apply_patch`), with `metadata.created_from = "openclaw"`. For
+Codex-native runs (PR #114) the spans also carry `metadata.source = "codex_app_server"`.
+Type `exit` to tear the container down.
+
+### Safety model
+
+This is meant for reviewing your own team's PRs; it hardens the obvious risks but
+is not a substitute for trusting the code you run.
+
+- **No host code execution.** The host runs only git (`checkout` + `git archive`).
+  `npm ci` / `npm pack` — and therefore any PR install scripts — run only inside the
+  container, never on your machine.
+- **No host config touched.** OpenClaw uses a throwaway container `HOME`; your real
+  `~/.openclaw` is never read or written.
+- **Hardened container.** Runs unprivileged with `--cap-drop ALL`,
+  `--security-opt no-new-privileges`, a `--read-only` root filesystem (writable
+  `tmpfs` only), and pid/memory caps. The source snapshot is mounted read-only.
+- **Disposable.** `--rm` deletes the container and its writable layer on exit.
+- **Secrets at runtime only.** Credentials come from the environment (or a gitignored
+  `.env`) via `docker run -e`; they are never baked into the image. Note they are
+  live inside the running container by design, so treat `OPIK_API_KEY` /
+  `OPENAI_API_KEY` as scoped, burnable keys rather than shared production secrets.
+- **Not a sandbox.** Plain Docker shares the host kernel and has open network egress
+  (needed to reach Opik/OpenAI). Do not use this to run PRs you do not trust.
+
 ## Contributing
 
 Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a PR.

--- a/README.md
+++ b/README.md
@@ -262,8 +262,8 @@ Run a PR, a branch, or the current working tree:
 
 The host runs only git: it checks out the PR/branch and exports a source snapshot
 with `git archive` (which executes no project code). The snapshot is mounted
-read-only into a clean Node 22 image that runs `openclaw@2026.3.2` (override with
-`OPENCLAW_VERSION`); the container does `npm ci && npm pack`, installs the build,
+read-only into a clean Node 22 image that runs the latest `openclaw` (pin a
+specific version with `OPENCLAW_VERSION`); the container does `npm ci && npm pack`, installs the build,
 starts the gateway, and drops you into a shell. List the configured agents, then
 run a turn that triggers tool calls:
 

--- a/README.md
+++ b/README.md
@@ -237,47 +237,74 @@ the host.
 
 Prerequisites:
 
-- Docker
+- Docker (with Compose)
 - Node.js `>=22.12.0` and npm `>=10` (used on the host to pack the plugin)
-- An Opik project plus an `OPENAI_API_KEY` for the live model call
+- An Opik project to send traces to (see "Opik targets" below)
 - Optional: the GitHub `gh` CLI (used to check out PRs, including forks)
 
-Set the required credentials in your shell or in a gitignored `.env` (copy from
-`.env.example`):
+### Model provider
+
+By default the turn is driven by a **local LLM running in an Ollama sidecar** — no
+model-provider account or API key required. This is enough to verify trace export
+and LLM/tool spans. The first run pulls the model (default `llama3.2:3b`) into a
+named volume and reuses it afterwards; local CPU inference is slow.
+
+To drive turns with a **real provider** instead (stronger tool-calling, or the Codex
+runtime that produces `codex_app_server` spans), pass `--provider openai` and supply
+your own `OPENAI_API_KEY`. The key is yours, injected at runtime only, never baked
+into the image.
+
+### Opik targets
+
+Point `OPIK_URL_OVERRIDE` at whichever Opik you want traces to land in:
+
+- **Comet Cloud:** `https://www.comet.com/opik/api` (set `OPIK_API_KEY`)
+- **Local self-hosted Opik on your host:** `http://host.docker.internal:5173/api`
+  (`OPIK_API_KEY` can be omitted for unauthenticated local deployments)
+
+Set config in your shell or in a gitignored `.env` (copy from `.env.example`):
 
 ```bash
-export OPIK_API_KEY="your-api-key"
 export OPIK_URL_OVERRIDE="https://www.comet.com/opik/api"
-export OPENAI_API_KEY="sk-..."
+export OPIK_API_KEY="your-api-key"        # optional for unauthenticated local Opik
 # optional: OPIK_PROJECT_NAME (default openclaw), OPIK_WORKSPACE (default default)
+# only for --provider openai:
+export OPENAI_API_KEY="sk-..."
 ```
 
 Run a PR, a branch, or the current working tree:
 
 ```bash
-./scripts/test-local.sh 114                 # check out PR #114 and test it
-./scripts/test-local.sh my-feature-branch   # test a branch
-./scripts/test-local.sh --current           # test the current working tree as-is
+./scripts/test-local.sh 114                      # PR #114, local Ollama (default)
+./scripts/test-local.sh my-feature-branch        # a branch
+./scripts/test-local.sh --current                # the current working tree as-is
+./scripts/test-local.sh 114 --provider openai    # drive with a real provider / Codex
 ```
 
 The host runs only git: it checks out the PR/branch and exports a source snapshot
 with `git archive` (which executes no project code). The snapshot is mounted
 read-only into a clean Node 22 image that runs the latest `openclaw` (pin a
-specific version with `OPENCLAW_VERSION`); the container does `npm ci && npm pack`, installs the build,
-starts the gateway, and drops you into a shell. List the configured agents, then
-run a turn that triggers tool calls:
+specific version with `OPENCLAW_VERSION`); the container does `npm ci && npm pack`,
+installs the build, configures the provider + Opik export, starts the gateway, and
+drops you into a shell. List the configured agents, then run a turn that triggers
+tool calls:
 
 ```bash
 openclaw agents list
-openclaw agent --agent <id> --message "Use the shell tool to run 'echo hello', then reply done."
-# or run the embedded agent without routing:
-openclaw agent --local --message "Use the shell tool to run 'echo hello', then reply done."
+openclaw agent --session-id test1 --message "Use the shell tool to run 'echo hello', then reply done."
 ```
 
 Then open your Opik project and confirm the trace shows an LLM span and a tool span
 (e.g. `shell` / `apply_patch`), with `metadata.created_from = "openclaw"`. For
-Codex-native runs (PR #114) the spans also carry `metadata.source = "codex_app_server"`.
-Type `exit` to tear the container down.
+Codex-native runs (PR #114, `--provider openai`) the spans also carry
+`metadata.source = "codex_app_server"`. Type `exit` to tear the container down.
+
+Notes:
+
+- Small local models call tools less reliably than hosted ones; if a turn answers in
+  text instead of calling the tool, retry or use `--provider openai`.
+- Override the local model with `OLLAMA_MODEL` (must be tool-capable, e.g.
+  `qwen2.5-coder:7b`).
 
 ### Safety model
 
@@ -294,11 +321,12 @@ is not a substitute for trusting the code you run.
   `tmpfs` only), and pid/memory caps. The source snapshot is mounted read-only.
 - **Disposable.** `--rm` deletes the container and its writable layer on exit.
 - **Secrets at runtime only.** Credentials come from the environment (or a gitignored
-  `.env`) via `docker run -e`; they are never baked into the image. Note they are
-  live inside the running container by design, so treat `OPIK_API_KEY` /
-  `OPENAI_API_KEY` as scoped, burnable keys rather than shared production secrets.
-- **Not a sandbox.** Plain Docker shares the host kernel and has open network egress
-  (needed to reach Opik/OpenAI). Do not use this to run PRs you do not trust.
+  `.env`); they are never baked into the image. Any key you pass (`OPIK_API_KEY`, or
+  `OPENAI_API_KEY` with `--provider openai`) is live inside the running container by
+  design, so treat it as scoped/burnable rather than a shared production secret. The
+  default Ollama provider needs no key at all.
+- **Not a sandbox.** Plain Docker shares the host kernel and has open network egress.
+  Do not use this to run PRs you do not trust.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -264,11 +264,14 @@ The host runs only git: it checks out the PR/branch and exports a source snapsho
 with `git archive` (which executes no project code). The snapshot is mounted
 read-only into a clean Node 22 image that runs `openclaw@2026.3.2` (override with
 `OPENCLAW_VERSION`); the container does `npm ci && npm pack`, installs the build,
-starts the gateway, and drops you into a shell. Run a turn that triggers tool
-calls, e.g.:
+starts the gateway, and drops you into a shell. List the configured agents, then
+run a turn that triggers tool calls:
 
 ```bash
-openclaw agent --agent main --message "Use the shell tool to run 'echo hello', then reply done."
+openclaw agents list
+openclaw agent --agent <id> --message "Use the shell tool to run 'echo hello', then reply done."
+# or run the embedded agent without routing:
+openclaw agent --local --message "Use the shell tool to run 'echo hello', then reply done."
 ```
 
 Then open your Opik project and confirm the trace shows an LLM span and a tool span

--- a/README.md
+++ b/README.md
@@ -238,9 +238,11 @@ the host.
 Prerequisites:
 
 - Docker (with Compose)
-- Node.js `>=22.12.0` and npm `>=10` (used on the host to pack the plugin)
 - An Opik project to send traces to (see "Opik targets" below)
 - Optional: the GitHub `gh` CLI (used to check out PRs, including forks)
+
+The host only needs `git` and Docker — `npm ci` / `npm pack` run inside the
+container, so no Node.js/npm toolchain is required on the host.
 
 ### Model provider
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,8 +17,9 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends git ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# OpenClaw version the plugin is built against (openclaw.build.openclawVersion).
-ARG OPENCLAW_VERSION=2026.3.2
+# OpenClaw version to test against. Defaults to latest so the tool tracks current
+# releases; pin via --build-arg OPENCLAW_VERSION=<version> for a reproducible run.
+ARG OPENCLAW_VERSION=latest
 ENV OPENCLAW_VERSION=${OPENCLAW_VERSION}
 
 # Keep the npm/npx cache outside paths that are masked by tmpfs at runtime, so the

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,39 @@
+# Isolated OpenClaw runtime for manual E2E testing of opik-openclaw PR/branch builds.
+# The plugin source is mounted and built at runtime, not baked in, so one image
+# serves every branch. The container is run hardened and read-only (see test-local.sh).
+# Digest-pinned for reproducibility (node:22-bookworm-slim as of 2026-06-17).
+# Refresh with: docker pull node:22-bookworm-slim && docker inspect --format '{{index .RepoDigests 0}}' node:22-bookworm-slim
+FROM node:22-bookworm-slim@sha256:e21fc383b50d5347dc7a9f1cae45b8f4e2f0d39f7ade28e4eef7d2934522b752
+
+# git lets the agent exercise apply_patch/shell tool calls against a real working tree.
+# The base image already ships current Debian security patches; the real risk
+# mitigation for this disposable container is the runtime hardening in test-local.sh
+# (unprivileged, cap-drop ALL, read-only rootfs, no-new-privileges, pid/memory caps).
+# Reproducibility comes from the digest-pinned base above; apt versions are left
+# unpinned because Debian stable drops superseded versions from its mirrors, which
+# would break the build on the next security update.
+# hadolint ignore=DL3008
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# OpenClaw version the plugin is built against (openclaw.build.openclawVersion).
+ARG OPENCLAW_VERSION=2026.3.2
+ENV OPENCLAW_VERSION=${OPENCLAW_VERSION}
+
+# Keep the npm/npx cache outside paths that are masked by tmpfs at runtime, so the
+# warmed OpenClaw download survives into the read-only container.
+ENV npm_config_cache=/opt/npm-cache
+RUN mkdir -p /opt/npm-cache \
+    && npx -y openclaw@"${OPENCLAW_VERSION}" --version \
+    && chmod -R a+rX /opt/npm-cache
+
+# Run as an unprivileged user; the base image ships a `node` user (uid 1000).
+# /work and /home/node are provided as writable tmpfs mounts at runtime.
+USER node
+WORKDIR /work
+ENV HOME=/home/node
+
+COPY --chown=node:node docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/docker-compose.ollama.yml
+++ b/docker/docker-compose.ollama.yml
@@ -1,0 +1,67 @@
+# Ollama-backed local E2E: a local LLM sidecar so a real OpenClaw turn can be driven
+# with no model-provider account or API key. test-local.sh sets the env vars below.
+#
+#   SRC_DIR    host path to the git-archive source snapshot (mounted read-only)
+#   OUT_DIR    host path for run artifacts / span results
+#   OLLAMA_MODEL  tool-capable model to pull and run (default llama3.2:3b)
+#
+# The tester keeps the same hardening as the plain `docker run` path; the ollama
+# service holds the model in a named volume so it is pulled once and reused.
+services:
+  ollama:
+    image: ollama/ollama
+    environment:
+      OLLAMA_KEEP_ALIVE: "30m"
+    volumes:
+      - ollama-models:/root/.ollama
+    networks:
+      - e2e
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+
+  tester:
+    image: opik-openclaw-e2e:local
+    depends_on:
+      ollama:
+        condition: service_healthy
+    environment:
+      MODEL_PROVIDER: ollama
+      OLLAMA_BASE_URL: "http://ollama:11434"
+      OLLAMA_MODEL: "${OLLAMA_MODEL:-llama3.2:3b}"
+      OPIK_API_KEY: "${OPIK_API_KEY}"
+      OPIK_URL_OVERRIDE: "${OPIK_URL_OVERRIDE}"
+      OPIK_PROJECT_NAME: "${OPIK_PROJECT_NAME:-openclaw}"
+      OPIK_WORKSPACE: "${OPIK_WORKSPACE:-default}"
+    volumes:
+      - "${SRC_DIR}:/src:ro"
+      - "${OUT_DIR}:/out"
+    networks:
+      - e2e
+    # Lets OPIK_URL_OVERRIDE point at a host-run local Opik via host.docker.internal.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    stdin_open: true
+    tty: true
+    # Hardening (mirrors scripts/test-local.sh): unprivileged, no new privileges,
+    # read-only rootfs with writable tmpfs only, bounded blast radius.
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges
+    read_only: true
+    pids_limit: 512
+    mem_limit: 4g
+    tmpfs:
+      - /work:exec,size=2g,uid=1000,gid=1000
+      - /home/node:exec,size=3g,uid=1000,gid=1000
+      - /tmp:size=512m,uid=1000,gid=1000
+
+networks:
+  e2e:
+    driver: bridge
+
+volumes:
+  ollama-models:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Runs inside the container. Builds the plugin from the read-only source snapshot
+# mounted at /src (so PR install scripts never run on the host), installs it into a
+# fresh OpenClaw home, renders config from OPIK_* env, starts the gateway, then hands
+# the engineer an interactive shell to run turns and observe spans in Opik.
+set -euo pipefail
+
+OPENCLAW="npx -y openclaw@${OPENCLAW_VERSION}"
+SRC_DIR="/src"
+BUILD_DIR="/work/plugin"
+CONFIG_DIR="${HOME}/.openclaw"
+CONFIG_PATH="${CONFIG_DIR}/openclaw.json"
+GATEWAY_LOG="/tmp/gateway.log"
+
+err() { printf '\033[31m[test-local] %s\033[0m\n' "$*" >&2; }
+info() { printf '\033[36m[test-local] %s\033[0m\n' "$*"; }
+
+if [[ ! -d "${SRC_DIR}" || ! -f "${SRC_DIR}/package.json" ]]; then
+  err "source snapshot not found at ${SRC_DIR} (expected it to be mounted)"
+  exit 1
+fi
+
+: "${OPIK_API_KEY:?OPIK_API_KEY is required}"
+: "${OPIK_URL_OVERRIDE:?OPIK_URL_OVERRIDE is required (e.g. https://www.comet.com/opik/api)}"
+: "${OPENAI_API_KEY:?OPENAI_API_KEY is required for the live model call}"
+OPIK_PROJECT_NAME="${OPIK_PROJECT_NAME:-openclaw}"
+OPIK_WORKSPACE="${OPIK_WORKSPACE:-default}"
+LIVE_MODEL="${OPENCLAW_LIVE_MODEL:-gpt-4o-mini}"
+GATEWAY_PORT="${OPENCLAW_GATEWAY_PORT:-18789}"
+GATEWAY_TOKEN="${OPENCLAW_GATEWAY_TOKEN:-local-e2e-token}"
+
+# npm needs a writable cache; the rootfs is read-only, so point it at tmpfs and
+# seed it from the image's warmed cache (which holds the pinned OpenClaw download).
+export npm_config_cache="${HOME}/.npm"
+mkdir -p "${npm_config_cache}"
+if [[ -d /opt/npm-cache ]]; then
+  cp -a /opt/npm-cache/. "${npm_config_cache}/" 2>/dev/null || true
+fi
+
+# Copy the read-only snapshot into a writable tmpfs dir and build there. Install
+# scripts run here, inside the locked-down container, never on the host.
+info "copying source snapshot into writable build dir..."
+mkdir -p "${BUILD_DIR}"
+cp -a "${SRC_DIR}/." "${BUILD_DIR}/"
+cd "${BUILD_DIR}"
+
+info "installing dependencies (npm ci)..."
+npm ci
+
+info "packing plugin (npm pack)..."
+TARBALL_NAME="$(npm pack --silent)"
+TARBALL_PATH="${BUILD_DIR}/${TARBALL_NAME}"
+[[ -f "${TARBALL_PATH}" ]] || { err "npm pack did not produce a tarball"; exit 1; }
+info "packed: ${TARBALL_NAME}"
+
+mkdir -p "${CONFIG_DIR}"
+
+# Mirror the config shape used by .scripts/live-e2e.mjs so the plugin loads with
+# conversation hooks enabled and traces are routed to the engineer's project.
+cat > "${CONFIG_PATH}" <<JSON
+{
+  "gateway": {
+    "mode": "local",
+    "bind": "loopback",
+    "auth": { "mode": "token", "token": "${GATEWAY_TOKEN}" },
+    "port": ${GATEWAY_PORT}
+  },
+  "agents": {
+    "defaults": {
+      "model": { "primary": "openai/${LIVE_MODEL}" }
+    }
+  },
+  "plugins": {
+    "allow": ["opik-openclaw"],
+    "entries": {
+      "opik-openclaw": {
+        "enabled": true,
+        "hooks": { "allowConversationAccess": true },
+        "config": {
+          "enabled": true,
+          "apiUrl": "${OPIK_URL_OVERRIDE}",
+          "apiKey": "${OPIK_API_KEY}",
+          "projectName": "${OPIK_PROJECT_NAME}",
+          "workspaceName": "${OPIK_WORKSPACE}",
+          "tags": ["local-docker-e2e"]
+        }
+      }
+    }
+  }
+}
+JSON
+
+export OPENCLAW_GATEWAY_TOKEN="${GATEWAY_TOKEN}"
+
+info "installing plugin build into OpenClaw..."
+${OPENCLAW} plugins install "${TARBALL_PATH}"
+
+info "starting gateway on port ${GATEWAY_PORT}..."
+${OPENCLAW} gateway run >"${GATEWAY_LOG}" 2>&1 &
+GATEWAY_PID=$!
+
+cleanup() {
+  ${OPENCLAW} gateway stop >/dev/null 2>&1 || true
+  if kill -0 "${GATEWAY_PID}" 2>/dev/null; then
+    kill "${GATEWAY_PID}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+ready=""
+for _ in $(seq 1 30); do
+  if ${OPENCLAW} health >/dev/null 2>&1; then
+    ready=1
+    break
+  fi
+  sleep 1
+done
+
+if [[ -z "${ready}" ]]; then
+  err "gateway failed to become ready; recent log:"
+  tail -n 40 "${GATEWAY_LOG}" >&2 || true
+  exit 1
+fi
+
+cat <<GUIDE
+
+$(info "gateway ready — plugin installed and tracing to Opik")
+
+  Project:   ${OPIK_PROJECT_NAME}
+  Workspace: ${OPIK_WORKSPACE}
+  Endpoint:  ${OPIK_URL_OVERRIDE}
+
+Run a turn that triggers tool calls, e.g.:
+
+  openclaw agent --agent main --message "Use the shell tool to run 'echo hello', then reply done."
+
+Then open your Opik project and confirm:
+  - an LLM span and a tool span (e.g. shell / apply_patch) under the trace
+  - trace metadata.created_from = "openclaw"
+  - for Codex-native runs (PR #114): span metadata.source = "codex_app_server"
+
+Gateway log: ${GATEWAY_LOG}
+Type 'exit' to tear everything down (container is --rm, nothing persists).
+
+GUIDE
+
+# Interactive shell for the engineer; if none is attached (non-tty run), keep the
+# gateway alive in the foreground so the container is still usable.
+if [[ $# -gt 0 ]]; then
+  exec "$@"
+elif [[ -t 0 ]]; then
+  exec bash
+else
+  wait "${GATEWAY_PID}"
+fi

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -20,14 +20,34 @@ if [[ ! -d "${SRC_DIR}" || ! -f "${SRC_DIR}/package.json" ]]; then
   exit 1
 fi
 
-: "${OPIK_API_KEY:?OPIK_API_KEY is required}"
 : "${OPIK_URL_OVERRIDE:?OPIK_URL_OVERRIDE is required (e.g. https://www.comet.com/opik/api)}"
-: "${OPENAI_API_KEY:?OPENAI_API_KEY is required for the live model call}"
+# Optional: unauthenticated local Opik deployments do not need a key.
+OPIK_API_KEY="${OPIK_API_KEY:-}"
 OPIK_PROJECT_NAME="${OPIK_PROJECT_NAME:-openclaw}"
 OPIK_WORKSPACE="${OPIK_WORKSPACE:-default}"
-LIVE_MODEL="${OPENCLAW_LIVE_MODEL:-gpt-4o-mini}"
 GATEWAY_PORT="${OPENCLAW_GATEWAY_PORT:-18789}"
 GATEWAY_TOKEN="${OPENCLAW_GATEWAY_TOKEN:-local-e2e-token}"
+
+# Model provider. Default is a local Ollama sidecar (no account, no real key).
+# Set MODEL_PROVIDER=openai (and OPENAI_API_KEY) to drive turns with a real
+# provider instead — e.g. to exercise the Codex runtime or a stronger model.
+MODEL_PROVIDER="${MODEL_PROVIDER:-ollama}"
+if [[ "${MODEL_PROVIDER}" == "ollama" ]]; then
+  OLLAMA_BASE_URL="${OLLAMA_BASE_URL:-http://ollama:11434}"
+  OLLAMA_MODEL="${OLLAMA_MODEL:-llama3.2:3b}"
+  # Declare the model's full context. OpenClaw blocks windows below 16000 AND sizes
+  # its prompt budget from this number, so it must be large enough to hold the agent
+  # system prompt — too small overflows regardless of model size.
+  OLLAMA_CONTEXT_WINDOW="${OLLAMA_CONTEXT_WINDOW:-131072}"
+  AGENT_MODEL="ollama/${OLLAMA_MODEL}"
+elif [[ "${MODEL_PROVIDER}" == "openai" ]]; then
+  : "${OPENAI_API_KEY:?OPENAI_API_KEY is required when MODEL_PROVIDER=openai}"
+  LIVE_MODEL="${OPENCLAW_LIVE_MODEL:-gpt-4o-mini}"
+  AGENT_MODEL="openai/${LIVE_MODEL}"
+else
+  err "unsupported MODEL_PROVIDER: ${MODEL_PROVIDER} (expected 'ollama' or 'openai')"
+  exit 1
+fi
 
 # GATEWAY_PORT is interpolated unquoted into the config JSON below; a non-integer
 # would produce invalid JSON and fail the gateway with an opaque error, so reject it now.
@@ -66,6 +86,39 @@ export OPENCLAW_GATEWAY_TOKEN="${GATEWAY_TOKEN}"
 # Write only the gateway + model defaults first. The plugin entry must NOT exist
 # yet: `openclaw plugins install` validates config and aborts if it references a
 # not-yet-installed plugin, and it injects plugins.entries.opik-openclaw itself.
+#
+# For Ollama, declare an explicit provider (baseUrl points at the sidecar; explicit
+# config disables auto-discovery, so a manual model entry is required). Use the
+# native Ollama API URL — no /v1 suffix, which would break tool calling.
+if [[ "${MODEL_PROVIDER}" == "ollama" ]]; then
+  PROVIDERS_BLOCK=$(cat <<JSON
+,
+  "models": {
+    "providers": {
+      "ollama": {
+        "apiKey": "ollama-local",
+        "baseUrl": "${OLLAMA_BASE_URL}",
+        "api": "ollama",
+        "models": [
+          {
+            "id": "${OLLAMA_MODEL}",
+            "name": "${OLLAMA_MODEL}",
+            "reasoning": false,
+            "input": ["text"],
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
+            "contextWindow": ${OLLAMA_CONTEXT_WINDOW},
+            "maxTokens": 2048
+          }
+        ]
+      }
+    }
+  }
+JSON
+)
+else
+  PROVIDERS_BLOCK=""
+fi
+
 cat > "${CONFIG_PATH}" <<JSON
 {
   "gateway": {
@@ -76,22 +129,31 @@ cat > "${CONFIG_PATH}" <<JSON
   },
   "agents": {
     "defaults": {
-      "model": { "primary": "openai/${LIVE_MODEL}" }
+      "model": { "primary": "${AGENT_MODEL}" }
     }
-  }
+  }${PROVIDERS_BLOCK}
 }
 JSON
 
 info "installing plugin build into OpenClaw..."
 ${OPENCLAW} plugins install "${TARBALL_PATH}"
 
-# Merge Opik settings into the install-updated config via config set (dot-path,
-# JSON5 value) rather than overwriting the file — install expands many defaults we
-# must preserve. No "hooks" key: openclaw 2026.3.2 rejects it as unrecognized; the
-# plugin registers its own conversation hooks on load.
+# Merge Opik settings into the install-updated config via config set, one field at a
+# time. Setting each scalar with its own dot-path passes the value as a raw string, so
+# quotes/backslashes in OPIK_* env vars are stored verbatim — a hand-built JSON5 blob
+# would break parsing or corrupt the value. install expands many defaults we preserve.
+# No "hooks" key: openclaw 2026.3.2 rejects it as unrecognized; the plugin registers
+# its own conversation hooks on load. tags is a fixed literal (no user input).
 info "configuring Opik export..."
-${OPENCLAW} config set plugins.entries.opik-openclaw.config \
-  "{enabled:true,apiUrl:\"${OPIK_URL_OVERRIDE}\",apiKey:\"${OPIK_API_KEY}\",projectName:\"${OPIK_PROJECT_NAME}\",workspaceName:\"${OPIK_WORKSPACE}\",tags:[\"local-docker-e2e\"]}"
+PLUGIN_CFG="plugins.entries.opik-openclaw.config"
+${OPENCLAW} config set "${PLUGIN_CFG}.enabled" true
+${OPENCLAW} config set "${PLUGIN_CFG}.apiUrl" "${OPIK_URL_OVERRIDE}"
+if [[ -n "${OPIK_API_KEY}" ]]; then
+  ${OPENCLAW} config set "${PLUGIN_CFG}.apiKey" "${OPIK_API_KEY}"
+fi
+${OPENCLAW} config set "${PLUGIN_CFG}.projectName" "${OPIK_PROJECT_NAME}"
+${OPENCLAW} config set "${PLUGIN_CFG}.workspaceName" "${OPIK_WORKSPACE}"
+${OPENCLAW} config set "${PLUGIN_CFG}.tags" '["local-docker-e2e"]'
 ${OPENCLAW} config set plugins.allow '["opik-openclaw"]'
 
 if ! ${OPENCLAW} config validate; then
@@ -130,6 +192,8 @@ cat <<GUIDE
 
 $(info "gateway ready — plugin installed and tracing to Opik")
 
+  Provider:  ${MODEL_PROVIDER}
+  Model:     ${AGENT_MODEL}
   Project:   ${OPIK_PROJECT_NAME}
   Workspace: ${OPIK_WORKSPACE}
   Endpoint:  ${OPIK_URL_OVERRIDE}

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -29,6 +29,13 @@ LIVE_MODEL="${OPENCLAW_LIVE_MODEL:-gpt-4o-mini}"
 GATEWAY_PORT="${OPENCLAW_GATEWAY_PORT:-18789}"
 GATEWAY_TOKEN="${OPENCLAW_GATEWAY_TOKEN:-local-e2e-token}"
 
+# GATEWAY_PORT is interpolated unquoted into the config JSON below; a non-integer
+# would produce invalid JSON and fail the gateway with an opaque error, so reject it now.
+if ! [[ "${GATEWAY_PORT}" =~ ^[0-9]+$ ]]; then
+  err "OPENCLAW_GATEWAY_PORT must be an integer, got: ${GATEWAY_PORT}"
+  exit 1
+fi
+
 # npm needs a writable cache; the rootfs is read-only, so point it at tmpfs and
 # seed it from the image's warmed cache (which holds the pinned OpenClaw download).
 export npm_config_cache="${HOME}/.npm"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -61,9 +61,11 @@ TARBALL_PATH="${BUILD_DIR}/${TARBALL_NAME}"
 info "packed: ${TARBALL_NAME}"
 
 mkdir -p "${CONFIG_DIR}"
+export OPENCLAW_GATEWAY_TOKEN="${GATEWAY_TOKEN}"
 
-# Mirror the config shape used by .scripts/live-e2e.mjs so the plugin loads with
-# conversation hooks enabled and traces are routed to the engineer's project.
+# Write only the gateway + model defaults first. The plugin entry must NOT exist
+# yet: `openclaw plugins install` validates config and aborts if it references a
+# not-yet-installed plugin, and it injects plugins.entries.opik-openclaw itself.
 cat > "${CONFIG_PATH}" <<JSON
 {
   "gateway": {
@@ -76,31 +78,26 @@ cat > "${CONFIG_PATH}" <<JSON
     "defaults": {
       "model": { "primary": "openai/${LIVE_MODEL}" }
     }
-  },
-  "plugins": {
-    "allow": ["opik-openclaw"],
-    "entries": {
-      "opik-openclaw": {
-        "enabled": true,
-        "hooks": { "allowConversationAccess": true },
-        "config": {
-          "enabled": true,
-          "apiUrl": "${OPIK_URL_OVERRIDE}",
-          "apiKey": "${OPIK_API_KEY}",
-          "projectName": "${OPIK_PROJECT_NAME}",
-          "workspaceName": "${OPIK_WORKSPACE}",
-          "tags": ["local-docker-e2e"]
-        }
-      }
-    }
   }
 }
 JSON
 
-export OPENCLAW_GATEWAY_TOKEN="${GATEWAY_TOKEN}"
-
 info "installing plugin build into OpenClaw..."
 ${OPENCLAW} plugins install "${TARBALL_PATH}"
+
+# Merge Opik settings into the install-updated config via config set (dot-path,
+# JSON5 value) rather than overwriting the file — install expands many defaults we
+# must preserve. No "hooks" key: openclaw 2026.3.2 rejects it as unrecognized; the
+# plugin registers its own conversation hooks on load.
+info "configuring Opik export..."
+${OPENCLAW} config set plugins.entries.opik-openclaw.config \
+  "{enabled:true,apiUrl:\"${OPIK_URL_OVERRIDE}\",apiKey:\"${OPIK_API_KEY}\",projectName:\"${OPIK_PROJECT_NAME}\",workspaceName:\"${OPIK_WORKSPACE}\",tags:[\"local-docker-e2e\"]}"
+${OPENCLAW} config set plugins.allow '["opik-openclaw"]'
+
+if ! ${OPENCLAW} config validate; then
+  err "config invalid after applying Opik settings"
+  exit 1
+fi
 
 info "starting gateway on port ${GATEWAY_PORT}..."
 ${OPENCLAW} gateway run >"${GATEWAY_LOG}" 2>&1 &
@@ -115,7 +112,7 @@ cleanup() {
 trap cleanup EXIT
 
 ready=""
-for _ in $(seq 1 30); do
+for _ in $(seq 1 40); do
   if ${OPENCLAW} health >/dev/null 2>&1; then
     ready=1
     break
@@ -137,9 +134,12 @@ $(info "gateway ready — plugin installed and tracing to Opik")
   Workspace: ${OPIK_WORKSPACE}
   Endpoint:  ${OPIK_URL_OVERRIDE}
 
-Run a turn that triggers tool calls, e.g.:
+Run a turn that triggers tool calls. List configured agents first, then target one:
 
-  openclaw agent --agent main --message "Use the shell tool to run 'echo hello', then reply done."
+  openclaw agents list
+  openclaw agent --agent <id> --message "Use the shell tool to run 'echo hello', then reply done."
+
+(Or 'openclaw agent --local --message ...' to run the embedded agent without routing.)
 
 Then open your Opik project and confirm:
   - an LLM span and a tool span (e.g. shell / apply_patch) under the trace

--- a/scripts/test-local.sh
+++ b/scripts/test-local.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Build an opik-openclaw PR/branch plugin and run it inside an isolated, hardened,
+# disposable Docker container against your own Opik project for manual end-to-end
+# verification.
+#
+# Usage:
+#   ./scripts/test-local.sh <PR# | branch | --current>
+#
+# Examples:
+#   ./scripts/test-local.sh 114                 # check out PR #114 and test it
+#   ./scripts/test-local.sh my-feature-branch   # test a branch
+#   ./scripts/test-local.sh --current           # test the current working tree as-is
+#
+# Safety model:
+#   - The host runs only git (checkout + `git archive`); it never runs npm, so PR
+#     install scripts cannot execute on your machine. The source snapshot is built
+#     and packed entirely inside the container.
+#   - The container runs unprivileged with all Linux capabilities dropped, a
+#     read-only root filesystem (writable tmpfs only), no-new-privileges, and pid /
+#     memory caps. It is --rm, so nothing persists on exit.
+#   - Opik credentials are read from the environment (or a gitignored .env) and
+#     passed at runtime only; they are never baked into the image.
+#
+# Required env (set directly or via .env):
+#   OPIK_API_KEY, OPIK_URL_OVERRIDE, OPENAI_API_KEY
+# Optional env:
+#   OPIK_PROJECT_NAME (default: openclaw), OPIK_WORKSPACE (default: default),
+#   OPENCLAW_LIVE_MODEL (default: gpt-4o-mini), OPENCLAW_VERSION (default: 2026.3.2)
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+IMAGE_TAG="opik-openclaw-e2e:local"
+OPENCLAW_VERSION="${OPENCLAW_VERSION:-2026.3.2}"
+
+err() { printf '\033[31m[test-local] %s\033[0m\n' "$*" >&2; }
+info() { printf '\033[36m[test-local] %s\033[0m\n' "$*"; }
+
+usage() {
+  # Print the leading comment block (skip the shebang, stop at the first non-comment line).
+  awk 'NR==1 {next} /^#/ {sub(/^# ?/, ""); print; next} {exit}' "${BASH_SOURCE[0]}"
+}
+
+TARGET="${1:-}"
+if [[ -z "${TARGET}" || "${TARGET}" == "-h" || "${TARGET}" == "--help" ]]; then
+  usage
+  [[ -z "${TARGET}" ]] && exit 1 || exit 0
+fi
+
+# Load .env if present so credentials can live in a gitignored file.
+if [[ -f "${REPO_ROOT}/.env" ]]; then
+  info "loading credentials from .env"
+  set -a
+  # shellcheck disable=SC1091
+  . "${REPO_ROOT}/.env"
+  set +a
+fi
+
+for var in OPIK_API_KEY OPIK_URL_OVERRIDE OPENAI_API_KEY; do
+  if [[ -z "${!var:-}" ]]; then
+    err "missing required env var: ${var}"
+    err "set it in your shell or in ${REPO_ROOT}/.env (see .env.example)"
+    exit 1
+  fi
+done
+
+command -v docker >/dev/null 2>&1 || { err "docker is not installed or not on PATH"; exit 1; }
+
+# --- Resolve the requested PR / branch to a git ref (no code execution) ---------
+# Checkout uses git only; we never run npm on the host, so a malicious PR's install
+# scripts cannot run here. The build happens inside the container from a git archive.
+resolve_ref() {
+  local target="$1"
+
+  if [[ "${target}" == "--current" ]]; then
+    info "testing current working tree (HEAD)"
+    echo "HEAD"
+    return
+  fi
+
+  if [[ -n "$(git status --porcelain)" ]]; then
+    err "working tree has uncommitted changes; commit/stash them or use --current"
+    exit 1
+  fi
+
+  if [[ "${target}" =~ ^[0-9]+$ ]]; then
+    info "checking out PR #${target}"
+    if command -v gh >/dev/null 2>&1; then
+      gh pr checkout "${target}" >&2
+    else
+      info "gh not found; fetching pull/${target}/head via git"
+      git fetch origin "pull/${target}/head:pr-${target}" >&2
+      git checkout "pr-${target}" >&2
+    fi
+  else
+    info "checking out branch ${target}"
+    git fetch origin "${target}" >/dev/null 2>&1 || true
+    git checkout "${target}" >&2
+  fi
+  echo "HEAD"
+}
+
+REF="$(resolve_ref "${TARGET}")"
+info "testing ref: $(git rev-parse --short "${REF}") ($(git rev-parse --abbrev-ref HEAD))"
+
+# --- Snapshot the source with git archive (pure git, runs no project code) ------
+SRC_DIR="$(mktemp -d)"
+trap 'rm -rf "${SRC_DIR}"' EXIT
+info "exporting source snapshot via git archive..."
+git archive --format=tar "${REF}" | tar -x -C "${SRC_DIR}"
+
+# --- Build the runtime image (toolchain only; no plugin source baked in) --------
+info "building Docker image ${IMAGE_TAG}..."
+docker build \
+  --build-arg "OPENCLAW_VERSION=${OPENCLAW_VERSION}" \
+  -t "${IMAGE_TAG}" \
+  -f docker/Dockerfile \
+  .
+
+# --- Run the hardened, disposable container -------------------------------------
+# Security flags:
+#   --rm                       container and its writable layer are deleted on exit
+#   --cap-drop ALL             drop all Linux capabilities
+#   --security-opt no-new-privileges  block setuid privilege escalation
+#   --read-only                root filesystem is immutable...
+#   --tmpfs ...                ...with writable tmpfs only where the build/runtime needs it
+#   --pids-limit / --memory    cap blast radius of a runaway or hostile build
+#   source mounted :ro         the snapshot the container builds from cannot be mutated
+info "starting isolated container (--rm, cap-drop, read-only rootfs; nothing persists)..."
+docker run --rm -it \
+  --cap-drop ALL \
+  --security-opt no-new-privileges \
+  --read-only \
+  --tmpfs /work:exec,size=1g,uid=1000,gid=1000 \
+  --tmpfs /home/node:exec,size=1g,uid=1000,gid=1000 \
+  --tmpfs /tmp:size=256m,uid=1000,gid=1000 \
+  --pids-limit 512 \
+  --memory 4g \
+  -v "${SRC_DIR}:/src:ro" \
+  -e "OPIK_API_KEY=${OPIK_API_KEY}" \
+  -e "OPIK_URL_OVERRIDE=${OPIK_URL_OVERRIDE}" \
+  -e "OPIK_PROJECT_NAME=${OPIK_PROJECT_NAME:-openclaw}" \
+  -e "OPIK_WORKSPACE=${OPIK_WORKSPACE:-default}" \
+  -e "OPENAI_API_KEY=${OPENAI_API_KEY}" \
+  -e "OPENCLAW_LIVE_MODEL=${OPENCLAW_LIVE_MODEL:-gpt-4o-mini}" \
+  "${IMAGE_TAG}"

--- a/scripts/test-local.sh
+++ b/scripts/test-local.sh
@@ -25,14 +25,16 @@
 #   OPIK_API_KEY, OPIK_URL_OVERRIDE, OPENAI_API_KEY
 # Optional env:
 #   OPIK_PROJECT_NAME (default: openclaw), OPIK_WORKSPACE (default: default),
-#   OPENCLAW_LIVE_MODEL (default: gpt-4o-mini), OPENCLAW_VERSION (default: 2026.3.2)
+#   OPENCLAW_LIVE_MODEL (default: gpt-4o-mini), OPENCLAW_VERSION (default: latest)
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${REPO_ROOT}"
 
 IMAGE_TAG="opik-openclaw-e2e:local"
-OPENCLAW_VERSION="${OPENCLAW_VERSION:-2026.3.2}"
+# Default to the latest published OpenClaw so the tool tracks current releases.
+# Pin via OPENCLAW_VERSION=<version> for a reproducible run.
+OPENCLAW_VERSION="${OPENCLAW_VERSION:-latest}"
 
 err() { printf '\033[31m[test-local] %s\033[0m\n' "$*" >&2; }
 info() { printf '\033[36m[test-local] %s\033[0m\n' "$*"; }

--- a/scripts/test-local.sh
+++ b/scripts/test-local.sh
@@ -4,12 +4,20 @@
 # verification.
 #
 # Usage:
-#   ./scripts/test-local.sh <PR# | branch | --current>
+#   ./scripts/test-local.sh <PR# | branch | --current> [--provider ollama|openai]
 #
 # Examples:
-#   ./scripts/test-local.sh 114                 # check out PR #114 and test it
+#   ./scripts/test-local.sh 114                 # check out PR #114, test it with local Ollama (default)
 #   ./scripts/test-local.sh my-feature-branch   # test a branch
 #   ./scripts/test-local.sh --current           # test the current working tree as-is
+#   ./scripts/test-local.sh 114 --provider openai   # drive turns with a real provider (OpenAI/Codex)
+#
+# Model provider:
+#   - ollama (default): runs a local LLM in a sidecar container — no model-provider
+#     account or API key. Good for verifying trace export + LLM/tool spans.
+#   - openai: drives turns with a real provider via your OPENAI_API_KEY. Needed for
+#     stronger tool-calling or the Codex runtime (codex_app_server spans). The key is
+#     yours, injected at runtime only, never baked into the image.
 #
 # Safety model:
 #   - The host runs only git (checkout + `git archive`); it never runs npm, so PR
@@ -18,14 +26,18 @@
 #   - The container runs unprivileged with all Linux capabilities dropped, a
 #     read-only root filesystem (writable tmpfs only), no-new-privileges, and pid /
 #     memory caps. It is --rm, so nothing persists on exit.
-#   - Opik credentials are read from the environment (or a gitignored .env) and
-#     passed at runtime only; they are never baked into the image.
+#   - Credentials are read from the environment (or a gitignored .env) and passed at
+#     runtime only; they are never baked into the image.
 #
 # Required env (set directly or via .env):
-#   OPIK_API_KEY, OPIK_URL_OVERRIDE, OPENAI_API_KEY
+#   OPIK_URL_OVERRIDE                        (always)
+#   OPENAI_API_KEY                           (only when --provider openai)
+# Optional env:
+#   OPIK_API_KEY                             (omit for unauthenticated local Opik)
 # Optional env:
 #   OPIK_PROJECT_NAME (default: openclaw), OPIK_WORKSPACE (default: default),
-#   OPENCLAW_LIVE_MODEL (default: gpt-4o-mini), OPENCLAW_VERSION (default: latest)
+#   OLLAMA_MODEL (default: llama3.2:3b), OPENCLAW_LIVE_MODEL (default: gpt-4o-mini),
+#   OPENCLAW_VERSION (default: latest)
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -44,10 +56,42 @@ usage() {
   awk 'NR==1 {next} /^#/ {sub(/^# ?/, ""); print; next} {exit}' "${BASH_SOURCE[0]}"
 }
 
-TARGET="${1:-}"
-if [[ -z "${TARGET}" || "${TARGET}" == "-h" || "${TARGET}" == "--help" ]]; then
+TARGET=""
+PROVIDER="ollama"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --provider)
+      PROVIDER="${2:-}"
+      shift 2
+      ;;
+    --provider=*)
+      PROVIDER="${1#*=}"
+      shift
+      ;;
+    *)
+      if [[ -z "${TARGET}" ]]; then
+        TARGET="$1"
+        shift
+      else
+        err "unexpected argument: $1"
+        exit 1
+      fi
+      ;;
+  esac
+done
+
+if [[ -z "${TARGET}" ]]; then
   usage
-  [[ -z "${TARGET}" ]] && exit 1 || exit 0
+  exit 1
+fi
+
+if [[ "${PROVIDER}" != "ollama" && "${PROVIDER}" != "openai" ]]; then
+  err "unsupported --provider: ${PROVIDER} (expected 'ollama' or 'openai')"
+  exit 1
 fi
 
 # Load .env if present so credentials can live in a gitignored file.
@@ -59,13 +103,19 @@ if [[ -f "${REPO_ROOT}/.env" ]]; then
   set +a
 fi
 
-for var in OPIK_API_KEY OPIK_URL_OVERRIDE OPENAI_API_KEY; do
+# OPIK_API_KEY is optional: unauthenticated local Opik deployments do not need one.
+REQUIRED_ENV=(OPIK_URL_OVERRIDE)
+[[ "${PROVIDER}" == "openai" ]] && REQUIRED_ENV+=(OPENAI_API_KEY)
+for var in "${REQUIRED_ENV[@]}"; do
   if [[ -z "${!var:-}" ]]; then
     err "missing required env var: ${var}"
     err "set it in your shell or in ${REPO_ROOT}/.env (see .env.example)"
     exit 1
   fi
 done
+
+# Default the optional key so it can be referenced safely under `set -u`.
+OPIK_API_KEY="${OPIK_API_KEY:-}"
 
 command -v docker >/dev/null 2>&1 || { err "docker is not installed or not on PATH"; exit 1; }
 
@@ -108,7 +158,7 @@ info "testing ref: $(git rev-parse --short "${REF}") ($(git rev-parse --abbrev-r
 
 # --- Snapshot the source with git archive (pure git, runs no project code) ------
 SRC_DIR="$(mktemp -d)"
-trap 'rm -rf "${SRC_DIR}"' EXIT
+trap 'rm -rf "${SRC_DIR}"' EXIT  # replaced by a provider-specific trap before the container runs
 info "exporting source snapshot via git archive..."
 git archive --format=tar "${REF}" | tar -x -C "${SRC_DIR}"
 
@@ -120,30 +170,53 @@ docker build \
   -f docker/Dockerfile \
   .
 
-# --- Run the hardened, disposable container -------------------------------------
-# Security flags:
-#   --rm                       container and its writable layer are deleted on exit
-#   --cap-drop ALL             drop all Linux capabilities
-#   --security-opt no-new-privileges  block setuid privilege escalation
-#   --read-only                root filesystem is immutable...
-#   --tmpfs ...                ...with writable tmpfs only where the build/runtime needs it
-#   --pids-limit / --memory    cap blast radius of a runaway or hostile build
-#   source mounted :ro         the snapshot the container builds from cannot be mutated
-info "starting isolated container (--rm, cap-drop, read-only rootfs; nothing persists)..."
-docker run --rm -it \
-  --cap-drop ALL \
-  --security-opt no-new-privileges \
-  --read-only \
-  --tmpfs /work:exec,size=1g,uid=1000,gid=1000 \
-  --tmpfs /home/node:exec,size=1g,uid=1000,gid=1000 \
-  --tmpfs /tmp:size=256m,uid=1000,gid=1000 \
-  --pids-limit 512 \
-  --memory 4g \
-  -v "${SRC_DIR}:/src:ro" \
-  -e "OPIK_API_KEY=${OPIK_API_KEY}" \
-  -e "OPIK_URL_OVERRIDE=${OPIK_URL_OVERRIDE}" \
-  -e "OPIK_PROJECT_NAME=${OPIK_PROJECT_NAME:-openclaw}" \
-  -e "OPIK_WORKSPACE=${OPIK_WORKSPACE:-default}" \
-  -e "OPENAI_API_KEY=${OPENAI_API_KEY}" \
-  -e "OPENCLAW_LIVE_MODEL=${OPENCLAW_LIVE_MODEL:-gpt-4o-mini}" \
-  "${IMAGE_TAG}"
+# Run artifacts (span results etc.) land here so they survive container teardown.
+OUT_DIR="$(mktemp -d)"
+info "run artifacts: ${OUT_DIR}"
+
+# The hardening below is identical across providers: unprivileged, cap-drop ALL,
+# no-new-privileges, read-only rootfs with writable tmpfs only, pid/memory caps, and
+# the source mounted :ro. Nothing persists on exit.
+if [[ "${PROVIDER}" == "ollama" ]]; then
+  # Local LLM sidecar via compose — no model-provider account or key. The model is
+  # pulled into a named volume (once) and the gateway reaches it over a private network.
+  OLLAMA_MODEL="${OLLAMA_MODEL:-llama3.2:3b}"
+  COMPOSE_FILE="${REPO_ROOT}/docker/docker-compose.ollama.yml"
+  export SRC_DIR OUT_DIR OLLAMA_MODEL OPIK_API_KEY OPIK_URL_OVERRIDE
+  export OPIK_PROJECT_NAME="${OPIK_PROJECT_NAME:-openclaw}"
+  export OPIK_WORKSPACE="${OPIK_WORKSPACE:-default}"
+
+  compose() { docker compose -f "${COMPOSE_FILE}" -p opik-openclaw-e2e "$@"; }
+  cleanup() { compose down -v --remove-orphans >/dev/null 2>&1 || true; rm -rf "${SRC_DIR}" "${OUT_DIR}"; }
+  trap cleanup EXIT
+
+  info "starting Ollama sidecar and pulling model ${OLLAMA_MODEL} (first run downloads it)..."
+  compose up -d ollama
+  compose exec -T ollama ollama pull "${OLLAMA_MODEL}"
+
+  info "starting isolated tester container (provider=ollama; nothing persists)..."
+  compose run --rm tester
+else
+  # Real provider (OpenAI/Codex): the user's key is injected at runtime only.
+  info "starting isolated container (provider=openai, --rm, cap-drop, read-only rootfs)..."
+  trap 'rm -rf "${SRC_DIR}" "${OUT_DIR}"' EXIT
+  docker run --rm -it \
+    --cap-drop ALL \
+    --security-opt no-new-privileges \
+    --read-only \
+    --tmpfs /work:exec,size=2g,uid=1000,gid=1000 \
+    --tmpfs /home/node:exec,size=3g,uid=1000,gid=1000 \
+    --tmpfs /tmp:size=512m,uid=1000,gid=1000 \
+    --pids-limit 512 \
+    --memory 4g \
+    -v "${SRC_DIR}:/src:ro" \
+    -v "${OUT_DIR}:/out" \
+    -e "MODEL_PROVIDER=openai" \
+    -e "OPIK_API_KEY=${OPIK_API_KEY}" \
+    -e "OPIK_URL_OVERRIDE=${OPIK_URL_OVERRIDE}" \
+    -e "OPIK_PROJECT_NAME=${OPIK_PROJECT_NAME:-openclaw}" \
+    -e "OPIK_WORKSPACE=${OPIK_WORKSPACE:-default}" \
+    -e "OPENAI_API_KEY=${OPENAI_API_KEY}" \
+    -e "OPENCLAW_LIVE_MODEL=${OPENCLAW_LIVE_MODEL:-gpt-4o-mini}" \
+    "${IMAGE_TAG}"
+fi


### PR DESCRIPTION
# User description

<img width="1960" height="2528" alt="image" src="https://github.com/user-attachments/assets/9a3262c9-d116-49d1-9baa-82cc2f2567ed" />

## Details

Adds a host script + Dockerfile that build a given opik-openclaw PR/branch plugin and run it inside an **isolated, hardened, disposable** Docker container, so an engineer can manually verify that LLM/tool spans land in their own Opik project — without relying on anyone else's environment or risking their machine.

This is the bare-minimum manual-E2E piece from the team sync; CI automation is a separate ticket.

**What's added**
- `scripts/test-local.sh` — resolves a `<PR# | branch | --current>` via **git only**, exports a `git archive` source snapshot, builds the image, and runs the hardened container.
- `docker/Dockerfile` — digest-pinned `node:22-bookworm-slim`, npx-pinned `openclaw@2026.3.2` with a warmed cache; plugin source is built at runtime, **not baked into the image**.
- `docker/entrypoint.sh` — copies the read-only snapshot into tmpfs, runs `npm ci && npm pack` **inside** the container, installs into a fresh OpenClaw home, renders config from `OPIK_*` env, starts the gateway, drops to an interactive shell.
- `.dockerignore`, README "Local Docker E2E testing" + "Safety model" section.

## ⚠️ Security review requested

This PR runs **arbitrary PR code** + an **LLM with a shell tool**, with live API keys. Please scrutinize the safety model — it is the point of the PR:

- **No host code execution.** Host runs only `git` (`checkout` + `git archive`, which executes no project code). `npm ci`/`npm pack` and therefore any PR install scripts run **only inside the container**.
- **No host config touched.** OpenClaw uses a throwaway container `HOME`; the real `~/.openclaw` is never read/written.
- **Hardened `docker run`:** unprivileged `node` user, `--cap-drop ALL`, `--security-opt no-new-privileges`, `--read-only` rootfs (writable `tmpfs` only, `uid=1000`), `--pids-limit 512`, `--memory 4g`, `--rm`. Source mounted `:ro`.
- **Secrets at runtime only** via `docker run -e` (or gitignored `.env`); never baked into the image. They are live inside the running container by design — README calls this out and recommends scoped/burnable keys + a scratch Opik project.
- **Honest limits documented:** plain Docker shares the host kernel and has open egress (needed for Opik/OpenAI); explicitly **not** for running untrusted PRs.

Open questions for reviewers:
- Are the `tmpfs` sizes / `--memory 4g` / `--pids-limit 512` caps appropriate?
- Any concern with open network egress vs. restricting to Opik + OpenAI only?
- Is digest-pin + documented `DL3008` ignore the right call vs. pinning apt versions?

## Change checklist
- [x] User facing (engineer-facing tooling + README)
- [x] Documentation updated (if needed)
- [ ] Tests added/updated (manual E2E tooling; no automated tests)
- [ ] Breaking changes documented (if any) — none

## Issues
- OPIK-6973

## Testing

Verified locally (not yet a full live turn — pending security review before running the OpenClaw gateway):
- `docker build` succeeds from the digest-pinned base; `npx openclaw@2026.3.2` resolves and warms.
- Hardened container run (real source snapshot): runs as `node`, rootfs confirmed read-only, `npm ci` + `npm pack` succeed in tmpfs → `opik-opik-openclaw-0.2.17.tgz`.
- Entrypoint guards fire (missing source / missing `OPIK_API_KEY`).
- `shellcheck` clean (both scripts); `hadolint` clean (Dockerfile).

**Still to do (manual, gated on this review):** run a real turn against PR #114, confirm tool spans (`shell` / `apply_patch`) and `metadata.source = "codex_app_server"` appear in Opik, and correct the documented `openclaw agent` flags / tool names if they differ in `2026.3.2`.

## Documentation

README gains a "Local Docker E2E testing" section (prerequisites, env vars, run commands, what to look for) and a "Safety model" subsection covering the guarantees and limits above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enable engineers to manually run any <code>opik-openclaw</code> PR by invoking <code>scripts/test-local.sh</code>, which resolves a ref, archives the source, and builds/runs a hardened Docker runtime that boots OpenClaw with the plugin inside a disposable container. Document the new local flow and its safety guarantees so teammates understand how to drive the gateway with either the default Ollama sidecar or a real provider.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/comet-ml/opik-openclaw/127?tool=ast&topic=Docs+%26+Safety>Docs & Safety</a>
        </td><td>Document prerequisites, provider options, and the safety model in the README so reviewers know how to run Local Docker E2E testing and trust the hardened guarantees when supplying live secrets.<details><summary>Modified files (1)</summary><ul><li>README.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>danield@comet.com</td><td>docs(test-local): drop...</td><td>June 22, 2026</td></tr>
<tr><td>vincentkoc@ieee.org</td><td>fix(e2e): allow opik c...</td><td>May 06, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/comet-ml/opik-openclaw/127?tool=ast&topic=Local+Docker+E2E>Local Docker E2E</a>
        </td><td>Enable the local Docker flow by scripting <code>scripts/test-local.sh</code> to resolve refs, snapshot the source, build and run the <code>opik-openclaw-e2e:local</code> image, and helm the hardened runtime defined in <code>docker/Dockerfile</code>, <code>docker/entrypoint.sh</code>, <code>docker/docker-compose.ollama.yml</code>, and <code>.dockerignore</code> so PR installs execute only inside the container.<details><summary>Modified files (5)</summary><ul><li>.dockerignore</li>
<li>docker/Dockerfile</li>
<li>docker/docker-compose.ollama.yml</li>
<li>docker/entrypoint.sh</li>
<li>scripts/test-local.sh</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>danield@comet.com</td><td>feat(test-local): defa...</td><td>June 21, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/comet-ml/opik-openclaw/127?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>