### PR TITLE
Drop the empty NODE_AUTH_TOKEN from the npm publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,8 +201,6 @@ jobs:
           else
             npm publish "./release-artifacts/${{ needs.validate.outputs.tarball_name }}" --provenance --access public
           fi
-        env:
-          NODE_AUTH_TOKEN: ""
 
   publish-clawhub:
     needs: validate


### PR DESCRIPTION
# User description
## Details

The `publish-npm` job sets `NODE_AUTH_TOKEN: ""` on the publish step. It is not needed and should not be there.

`@opik/opik-openclaw` publishes via npm trusted publishing (OIDC): `id-token: write` is declared, and the preceding "Prepare trusted publishing auth" step already removes the `//registry.npmjs.org/:_authToken` stub that `setup-node` writes into `~/.npmrc`. With the stub gone there is no credential for `NODE_AUTH_TOKEN` to populate, so the variable has no effect.

It is worth removing anyway, because `NODE_AUTH_TOKEN` being set is precisely the failure mode to avoid: when npm sees a token it uses it and **silently skips OIDC**, publishing without provenance. An empty value is harmless, but it leaves a variable named after the exact anti-pattern sitting on the publish step, where the next person to touch this file may reasonably assume it wants a real value.

No behaviour change — the publish path is unchanged and `0.2.17` already publishes with a provenance attestation.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Testing

`python3 -c "import yaml; yaml.safe_load(...)"` — parses. `grep -rn NODE_AUTH_TOKEN .github/workflows/` returns nothing after the change. The publish step's `run:` block is untouched.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Remove the empty <code>NODE_AUTH_TOKEN</code> environment variable from the npm publish workflow while preserving trusted publishing through OIDC and the existing provenance-enabled publish command.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guys@comet.com</td><td>Drop the empty NODE_AU...</td><td>August 27, 2026</td></tr>
<tr><td>vincentkoc@ieee.org</td><td>fix(ci): keep ClawHub ...</td><td>May 22, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/comet-ml/opik-openclaw/143?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>